### PR TITLE
perf: infobox screenshot robustness

### DIFF
--- a/src/plugins/mediawiki/infoboxDefinition.ts
+++ b/src/plugins/mediawiki/infoboxDefinition.ts
@@ -13,9 +13,8 @@ export const INFOBOX_DEFINITION: {
   injectStyles?: string
 }[] = [
   // 萌娘百科
-  {
-    match: (url) => url.host.endsWith('moegirl.org.cn'),
-    selector: [
+  (() => {
+    const selectors = [
       // 标准信息框
       '.mw-parser-output .infotemplatebox',
       '.mw-parser-output table.infobox2',
@@ -23,27 +22,26 @@ export const INFOBOX_DEFINITION: {
       '.mw-parser-output table.infoboxSpecial',
       // 旧版兼容
       '.mw-parser-output table.infobox',
-    ],
-    injectStyles: `
-      /* 隐藏部分妨碍截图的元素 */
-      /* 顶部导航栏和悬浮工具栏 */
-      body #moe-full-container > header#moe-global-header, body #moe-full-container > #moe-global-toolbar,
-      /* 右下角悬浮的功能按钮 */
-      #bottomRightCorner, 
-      /* 全站公告弹窗 */
-      body > .n-modal-container,
-      /* [[WAF]] */
-      .mw-parser-output [data-id="lr-overlay"]
-      {
-        display: none !important;
-      }
+    ]
+    return {
+      match: (url) => url.host.endsWith('moegirl.org.cn'),
+      selector: selectors,
+      injectStyles: `
+        /* 隐藏妨碍截图的元素 */
+        ${selectors.join(', ')} {
+          visibility: visible;
+          :not(&, & *) {
+            visibility: hidden;
+          }
+        }
 
-      /* 调整信息框外观 */
-      .mw-parser-output .infotemplatebox {
-        margin: 1rem !important;
-      }
-      `,
-  },
+        /* 调整信息框外观 */
+        .mw-parser-output .infotemplatebox {
+          margin: 1rem !important;
+        }
+        `,
+    }
+  })(),
   // Minecraft Wiki
   {
     match: (url) => url.host === 'minecraft.fandom.com',


### PR DESCRIPTION
隐藏所有不属于 infobox 的元素，而非隐藏预定义的一部分。

## 原因

曾经出现 infobox 被某个元素遮挡的情况，如：

![image](https://github.com/user-attachments/assets/8e688d75-2e45-4373-a44d-c80775cd0d68)

48ec5cf58407682348ca841fe64cd9215b0d7717 修复了该特例，但对其他情形无效。

此 PR 通过 `visibility: hidden` 隐藏所有infobox外的元素，可以避免未来可能出现的任何遮挡，效果：

![image](https://github.com/user-attachments/assets/0a15545d-a6de-40c2-b929-2d589e1bded2)