### PR TITLE
chore: update docker-compose.yml to adapt to llonebot v5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,14 +74,13 @@ services:
     image: initialencounter/llonebot:latest
     environment:
       VNC_PASSWD: ${VNC_PASSWD}
-    privileged: true
     mem_limit: 1g
     restart: always
     ports:
       - '6788:7081' # VNC
     volumes:
-      - liteloader_data:/LiteLoader/data
-      - qqnt_data:/data/.config/QQ
+      - llonebot_data:/root/llonebot
+      - qqnt_data:/root/.config/QQ
     networks:
       sili-network:
         aliases:


### PR DESCRIPTION
The current docker image has removed bwrap, so the privileged mode is not required.

If you want to specify the image tag, you can do it like this: initialencounter/llonebot:v5.0.1

好的，这是翻译成中文的 pull request 摘要：

## Sourcery 提供的摘要

更新 docker-compose.yml 以适应 llonebot v5 的兼容性，具体包括：移除不必要的特权模式、调整数据卷路径以及支持自定义镜像标签。

杂项：
- 从 llonebot 服务中移除特权模式
- 更新卷挂载路径为 /root/llonebot 和 /root/.config/QQ
- 允许指定自定义的 llonebot 镜像标签，而不是使用 latest

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update docker-compose.yml to adapt to llonebot v5 compatibility by removing unnecessary privileged mode, adjusting data volume paths, and supporting custom image tags.

Chores:
- Remove privileged mode from the llonebot service
- Update volume mount paths to /root/llonebot and /root/.config/QQ
- Allow specifying a custom llonebot image tag instead of using latest

</details>