### PR TITLE
feat(llm-admin): per-user LLM admin console (memory / session management)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -80,6 +80,13 @@
         "yml-register": "^1.2.5",
       },
     },
+    "plugins/llm-admin": {
+      "name": "koishi-plugin-llm-admin",
+      "version": "0.0.0",
+      "peerDependencies": {
+        "koishi": "^4.18.0",
+      },
+    },
     "plugins/llm-dashboard": {
       "name": "koishi-plugin-llm-dashboard",
       "version": "0.0.0",
@@ -1146,6 +1153,8 @@
     "koishi-plugin-github": ["koishi-plugin-github@5.5.1", "https://registry.npmmirror.com/koishi-plugin-github/-/koishi-plugin-github-5.5.1.tgz", { "dependencies": { "@octokit/webhooks-types": "5.8.0", "koishi-plugin-markdown": "1.1.1" }, "peerDependencies": { "koishi": "4.18.0" } }, "sha512-MUbkKVCduefoIndKU7MbAiwXizYjGdmOXHeUWaH+gFs8Mts0TRroHD17x/PYRH3ogAzvVuug8XowQoYZFVG9aA=="],
 
     "koishi-plugin-image-search": ["koishi-plugin-image-search@4.3.2", "https://registry.npmmirror.com/koishi-plugin-image-search/-/koishi-plugin-image-search-4.3.2.tgz", { "dependencies": { "cheerio": "1.0.0-rc.12", "iqdb-client": "1.1.0", "nhentai-api": "3.4.3" }, "peerDependencies": { "koishi": "4.18.0" } }, "sha512-D/toPepRFR2Ta9k8iUVc3Hhu0hxVlpuFjUOq+aVqYy9fdHrzoDKDmD4fgZga8ox/gMrzYKNcsIAWioA97LA6JQ=="],
+
+    "koishi-plugin-llm-admin": ["koishi-plugin-llm-admin@workspace:plugins/llm-admin"],
 
     "koishi-plugin-llm-dashboard": ["koishi-plugin-llm-dashboard@workspace:plugins/llm-dashboard"],
 

--- a/docs/superpowers/plans/2026-07-09-llm-admin.md
+++ b/docs/superpowers/plans/2026-07-09-llm-admin.md
@@ -1,0 +1,842 @@
+# LLM 用户管理控制台 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把已验证的读侧原型（commit `94cdae7`）固化为带测试的正式实现，补上分页、N+1 修复、以及记忆/会话写操作。
+
+**Architecture:** 独立 workspace 包 `plugins/llm-admin`（`koishi-plugin-llm-admin`）。后端 TS（bun 直跑，不构建）注册 authority-4 console listener + `addEntry`；前端手写浏览器 ESM（vue-router query 路由 + Vue `h()`）。把原型内联的聚合/过滤逻辑抽成纯函数单测，listener 与前端走浏览器实机验证。
+
+**Tech Stack:** koishi 4.18 + @koishijs/console，bun runtime，vitest，手写 ESM（伪包 `../vue.js` / `../client.js` / `../vue-router.js`）。
+
+## Global Constraints
+
+- **权限**：页面 + **全部 listener** 一律 `{ authority: 4 }`（含读操作）。常量 `const AUTH = 4`。
+- **隐私**：服务端日志**不落**记忆/会话正文（只记 id/计数）；破坏性写操作（清空记忆、强制轮转）前端**二次确认**；会话回放默认只拉最近 N=20 轮。
+- **token 聚合陷阱**：`cachedTokens ⊂ promptTokens`、`reasoningTokens ⊂ completionTokens`——**不重复计入 total**；字段缺失 `?? 0`；`totalTokens` 缺省回退 `prompt+completion`。
+- **openai_chat 排序键**：`{ turn_number: 'asc', intra_turn_seq: 'asc', id: 'asc' }`（`time` 是 wall-clock、不单调，禁作排序键）。
+- **记忆键**：`(platform, user_id)`，`user_id = String(koishi user.id)`，`platform` 归一化 `onebot → 'qq'`。写时 platform 取现有 meta 的 `platform`；无现有行则取该用户首个 binding 的 platform 归一化。
+- **前端已验证机制（照原型，勿改坏）**：`resolveComponent('k-layout'/'k-card')`；鉴权就绪门（首个 `send` 等 `store.user`）；`addEntry` 指向 `resolve(ctx.baseDir, 'node_modules/koishi-plugin-llm-admin/client')`；vue-router **query** 路由（`?user=&session=`）。
+- **前端手写 ESM 保持紧凑风，勿跑 prettier**（会 reflow 污染 diff）；只对**改动过的后端 `.ts`** 跑 prettier，单独收尾提交。
+- **UI 任务的浏览器验证由控制器用 claude-in-chrome 做**（改完 `docker compose restart core`）；implementer 只负责写码 + 能跑的纯函数单测 + commit，不碰浏览器自动化。
+- 本地命令前缀 `;`；测试 `npx vitest run plugins/llm-admin/__tests__`。
+
+---
+
+### Task 1: 抽出 `aggregate-user.ts` 纯函数 + 单测
+
+把原型 `index.ts` 里 `llm-admin/overview` listener 内联的用量聚合抽成纯函数，便于单测。
+
+**Files:**
+- Create: `plugins/llm-admin/aggregate-user.ts`
+- Create: `plugins/llm-admin/__tests__/aggregate-user.test.ts`
+- Modify: `plugins/llm-admin/index.ts`（overview listener 改调纯函数）
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export interface Usage { promptTokens?: number; completionTokens?: number; totalTokens?: number; cachedTokens?: number }
+  export interface UserUsageRow { time: number; model: string; usage: Usage | null }
+  export interface UserIdentity { id: number; name: string; account: string }
+  export interface UserOverview extends UserIdentity {
+    sessionCount: number
+    firstActive: number | null
+    lastActive: number | null
+    calls: number
+    totalTokens: number; promptTokens: number; completionTokens: number; cachedTokens: number
+    models: Array<{ model: string; calls: number; totalTokens: number }>
+    trend: Array<{ date: string; promptTokens: number; completionTokens: number }>
+  }
+  export function aggregateUserOverview(
+    rows: UserUsageRow[], sessionCount: number, identity: UserIdentity, now: number, rangeDays?: number
+  ): UserOverview
+  ```
+
+- [ ] **Step 1: 写失败测试** — `plugins/llm-admin/__tests__/aggregate-user.test.ts`
+
+```ts
+import { describe, expect, it } from 'vitest'
+
+import { type UserUsageRow, aggregateUserOverview } from '../aggregate-user'
+
+const DAY = 86_400_000
+const now = 1_752_000_000_000
+const idt = { id: 1, name: 'Alice', account: 'qq:100' }
+
+function row(p: Partial<UserUsageRow> = {}): UserUsageRow {
+  return { time: now - DAY, model: 'gpt-4o', usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 }, ...p }
+}
+
+describe('aggregateUserOverview', () => {
+  it('sums tokens without double-counting cached', () => {
+    const o = aggregateUserOverview(
+      [row({ usage: { promptTokens: 200, completionTokens: 100, totalTokens: 300, cachedTokens: 80 } })],
+      3, idt, now
+    )
+    expect(o.calls).toBe(1)
+    expect(o.totalTokens).toBe(300)
+    expect(o.promptTokens).toBe(200)
+    expect(o.completionTokens).toBe(100)
+    expect(o.cachedTokens).toBe(80)
+    expect(o.sessionCount).toBe(3)
+    expect(o.id).toBe(1)
+    expect(o.name).toBe('Alice')
+    expect(o.account).toBe('qq:100')
+  })
+
+  it('falls back total = prompt + completion when totalTokens missing', () => {
+    const o = aggregateUserOverview([row({ usage: { promptTokens: 30, completionTokens: 20 } })], 0, idt, now)
+    expect(o.totalTokens).toBe(50)
+  })
+
+  it('handles null usage without throwing', () => {
+    const o = aggregateUserOverview([row({ usage: null })], 0, idt, now)
+    expect(o.calls).toBe(1)
+    expect(o.totalTokens).toBe(0)
+  })
+
+  it('ranks models by total tokens desc', () => {
+    const o = aggregateUserOverview(
+      [
+        row({ model: 'a', usage: { totalTokens: 100 } }),
+        row({ model: 'b', usage: { totalTokens: 500 } }),
+        row({ model: 'a', usage: { totalTokens: 100 } }),
+      ],
+      0, idt, now
+    )
+    expect(o.models[0]).toEqual({ model: 'b', calls: 1, totalTokens: 500 })
+    expect(o.models[1]).toEqual({ model: 'a', calls: 2, totalTokens: 200 })
+  })
+
+  it('tracks first/last active', () => {
+    const o = aggregateUserOverview([row({ time: now - 5 * DAY }), row({ time: now - DAY })], 0, idt, now)
+    expect(o.firstActive).toBe(now - 5 * DAY)
+    expect(o.lastActive).toBe(now - DAY)
+  })
+
+  it('builds a continuous daily trend over rangeDays whose length covers the window', () => {
+    const o = aggregateUserOverview([row({ time: now - DAY })], 0, idt, now, 30)
+    expect(o.trend.length).toBeGreaterThanOrEqual(30)
+    const keys = new Set(o.trend.map((d) => d.date))
+    expect(keys.size).toBe(o.trend.length) // no duplicate days
+  })
+
+  it('leaves overview zeroed for a user with no rows', () => {
+    const o = aggregateUserOverview([], 0, idt, now)
+    expect(o.calls).toBe(0)
+    expect(o.firstActive).toBeNull()
+    expect(o.models).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `npx vitest run plugins/llm-admin/__tests__/aggregate-user.test.ts`
+Expected: FAIL（`aggregate-user` 模块不存在）
+
+- [ ] **Step 3: 写实现** — `plugins/llm-admin/aggregate-user.ts`
+
+```ts
+export interface Usage {
+  promptTokens?: number
+  completionTokens?: number
+  totalTokens?: number
+  cachedTokens?: number
+}
+export interface UserUsageRow {
+  time: number
+  model: string
+  usage: Usage | null
+}
+export interface UserIdentity {
+  id: number
+  name: string
+  account: string
+}
+export interface UserOverview extends UserIdentity {
+  sessionCount: number
+  firstActive: number | null
+  lastActive: number | null
+  calls: number
+  totalTokens: number
+  promptTokens: number
+  completionTokens: number
+  cachedTokens: number
+  models: Array<{ model: string; calls: number; totalTokens: number }>
+  trend: Array<{ date: string; promptTokens: number; completionTokens: number }>
+}
+
+const DAY = 86_400_000
+
+// cachedTokens ⊂ promptTokens — 展示用，不计入 total。
+function tok(u: Usage | null) {
+  const prompt = u?.promptTokens ?? 0
+  const completion = u?.completionTokens ?? 0
+  const cached = u?.cachedTokens ?? 0
+  return { prompt, completion, cached, total: u?.totalTokens ?? prompt + completion }
+}
+
+function localDate(time: number): string {
+  const d = new Date(time)
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${d.getFullYear()}-${m}-${day}`
+}
+
+export function aggregateUserOverview(
+  rows: UserUsageRow[],
+  sessionCount: number,
+  identity: UserIdentity,
+  now: number,
+  rangeDays = 30
+): UserOverview {
+  let totalTokens = 0
+  let promptTokens = 0
+  let completionTokens = 0
+  let cachedTokens = 0
+  let firstActive: number | null = null
+  let lastActive: number | null = null
+  const byModel = new Map<string, { calls: number; totalTokens: number }>()
+  const since = now - rangeDays * DAY
+  const byDay = new Map<string, { promptTokens: number; completionTokens: number }>()
+
+  for (const r of rows) {
+    const t = tok(r.usage)
+    totalTokens += t.total
+    promptTokens += t.prompt
+    completionTokens += t.completion
+    cachedTokens += t.cached
+    if (firstActive === null || r.time < firstActive) firstActive = r.time
+    if (lastActive === null || r.time > lastActive) lastActive = r.time
+    const m = byModel.get(r.model) ?? { calls: 0, totalTokens: 0 }
+    m.calls += 1
+    m.totalTokens += t.total
+    byModel.set(r.model, m)
+    if (r.time >= since) {
+      const key = localDate(r.time)
+      const b = byDay.get(key) ?? { promptTokens: 0, completionTokens: 0 }
+      b.promptTokens += t.prompt
+      b.completionTokens += t.completion
+      byDay.set(key, b)
+    }
+  }
+
+  const trend: UserOverview['trend'] = []
+  for (let d = new Date(since); d.getTime() <= now; d.setDate(d.getDate() + 1)) {
+    const key = localDate(d.getTime())
+    trend.push({ date: key, ...(byDay.get(key) ?? { promptTokens: 0, completionTokens: 0 }) })
+  }
+
+  return {
+    ...identity,
+    sessionCount,
+    firstActive,
+    lastActive,
+    calls: rows.length,
+    totalTokens,
+    promptTokens,
+    completionTokens,
+    cachedTokens,
+    models: [...byModel.entries()]
+      .map(([model, v]) => ({ model, ...v }))
+      .sort((a, b) => b.totalTokens - a.totalTokens),
+    trend,
+  }
+}
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `npx vitest run plugins/llm-admin/__tests__/aggregate-user.test.ts`
+Expected: PASS（7 tests）
+
+- [ ] **Step 5: 把 overview listener 改调纯函数** — `plugins/llm-admin/index.ts`
+
+删掉 overview listener 里内联的 `tok`/`localDate`/聚合循环/trend 循环，改为：从 DB 取 `rows`（`openai_chat` where `conversation_owner=id, role='assistant'`, fields `['time','model','usage']`）+ `sessionsOfUser` 计数 + `resolveIdentities([id])`，然后：
+
+```ts
+import { type UserUsageRow, aggregateUserOverview } from './aggregate-user'
+// ...
+const identity = { id, name: nameMap.get(id) || '', account: acctMap.get(id) || '' }
+return aggregateUserOverview(rows as unknown as UserUsageRow[], sessionsOfUser.length, identity, Date.now())
+```
+
+顶部若还有未用到的 `tok`/`localDate`/`Usage`/`DAY`，若无其它引用则删除（trend/model 类型现在来自 `aggregate-user`）。
+
+- [ ] **Step 6: 跑全量确认无回归 + 提交**
+
+Run: `npx vitest run plugins/llm-admin/__tests__`
+Expected: PASS
+
+```bash
+git add plugins/llm-admin/aggregate-user.ts plugins/llm-admin/__tests__/aggregate-user.test.ts plugins/llm-admin/index.ts
+git commit -m "refactor(llm-admin): extract aggregateUserOverview pure fn + unit tests"
+```
+
+（控制器随后 restart core + 浏览器核对总览渲染不变。）
+
+---
+
+### Task 2: 搜索 & 会话列表分页 + 修 N+1
+
+**Files:**
+- Create: `plugins/llm-admin/filters.ts`
+- Create: `plugins/llm-admin/__tests__/filters.test.ts`
+- Modify: `plugins/llm-admin/index.ts`（search / sessions listener）
+- Modify: `plugins/llm-admin/client/index.js`（结果/会话列表「加载更多」）
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export function matchUser(u: { id: number; name: string; account: string }, query: string): boolean
+  export function paginate<T>(arr: T[], limit: number, offset: number): { total: number; page: T[] }
+  ```
+- 后端事件签名改为：
+  ```ts
+  'llm-admin/search'(payload: { q: string; limit?: number; offset?: number }): { total: number; users: AdminUser[] }
+  'llm-admin/sessions'(payload: { id: number; limit?: number; offset?: number }): { total: number; rows: SessionRow[] }
+  ```
+
+- [ ] **Step 1: 写失败测试** — `plugins/llm-admin/__tests__/filters.test.ts`
+
+```ts
+import { describe, expect, it } from 'vitest'
+
+import { matchUser, paginate } from '../filters'
+
+const u = { id: 42, name: '爸爸', account: 'qq:824399619' }
+
+describe('matchUser', () => {
+  it('matches exact #id and bare id', () => {
+    expect(matchUser(u, '#42')).toBe(true)
+    expect(matchUser(u, '42')).toBe(true)
+    expect(matchUser(u, '4')).toBe(false) // id 是精确匹配，不是子串
+  })
+  it('matches account and name substrings, case-insensitive', () => {
+    expect(matchUser(u, '8243')).toBe(true)
+    expect(matchUser(u, 'QQ:')).toBe(true)
+    expect(matchUser(u, '爸')).toBe(true)
+    expect(matchUser(u, 'zzz')).toBe(false)
+  })
+  it('empty query matches all', () => {
+    expect(matchUser(u, '')).toBe(true)
+    expect(matchUser(u, '  ')).toBe(true)
+  })
+})
+
+describe('paginate', () => {
+  const arr = [1, 2, 3, 4, 5]
+  it('returns total and the requested window', () => {
+    expect(paginate(arr, 2, 0)).toEqual({ total: 5, page: [1, 2] })
+    expect(paginate(arr, 2, 2)).toEqual({ total: 5, page: [3, 4] })
+    expect(paginate(arr, 2, 4)).toEqual({ total: 5, page: [5] })
+  })
+  it('offset past end yields empty page but real total', () => {
+    expect(paginate(arr, 2, 10)).toEqual({ total: 5, page: [] })
+  })
+})
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `npx vitest run plugins/llm-admin/__tests__/filters.test.ts`
+Expected: FAIL（`filters` 不存在）
+
+- [ ] **Step 3: 写实现** — `plugins/llm-admin/filters.ts`
+
+```ts
+export function matchUser(
+  u: { id: number; name: string; account: string },
+  query: string
+): boolean {
+  const q = (query ?? '').trim().toLowerCase()
+  if (!q) return true
+  return (
+    `#${u.id}` === q ||
+    String(u.id) === q ||
+    u.account.toLowerCase().includes(q) ||
+    u.name.toLowerCase().includes(q)
+  )
+}
+
+export function paginate<T>(arr: T[], limit: number, offset: number): { total: number; page: T[] } {
+  const off = Math.max(0, offset | 0)
+  const lim = Math.max(0, limit | 0)
+  return { total: arr.length, page: arr.slice(off, off + lim) }
+}
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `npx vitest run plugins/llm-admin/__tests__/filters.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: search listener 用 matchUser + paginate** — `plugins/llm-admin/index.ts`
+
+```ts
+import { matchUser, paginate } from './filters'
+// ...
+ctx.console.addListener(
+  'llm-admin/search',
+  async ({ q, limit = 50, offset = 0 }) => {
+    const sessions = await db.get('openai_session', {}, { fields: ['conversation_owner'] })
+    const ids = [...new Set(sessions.map((s) => s.conversation_owner))]
+    const { nameMap, acctMap } = await resolveIdentities(ids)
+    const all = ids
+      .map((id) => ({ id, name: nameMap.get(id) || '', account: acctMap.get(id) || '' }))
+      .filter((u) => matchUser(u, q))
+      .sort((a, b) => a.id - b.id)
+    const { total, page } = paginate(all, limit, offset)
+    return { total, users: page }
+  },
+  { authority: AUTH }
+)
+```
+
+- [ ] **Step 6: sessions listener 分页 + 修 N+1** — `plugins/llm-admin/index.ts`
+
+原型对每个会话单查一次轮数（N+1）。改为：先取该用户全部会话行、排序、`paginate` 到当前页，**只对当前页的 conversation_id 批量查一次** `turn_number` 再分组：
+
+```ts
+ctx.console.addListener(
+  'llm-admin/sessions',
+  async ({ id, limit = 30, offset = 0 }) => {
+    const rows = await db.get(
+      'openai_session',
+      { conversation_owner: id },
+      { fields: ['conversation_id', 'user_first_msg', 'started_at', 'last_used_at', 'prev_session_id'] }
+    )
+    const user = await db.get('user', { id }, { fields: ['openai_last_conversation_id'] })
+    const currentConv = (user[0] as any)?.openai_last_conversation_id ?? ''
+
+    const sorted = [...rows].sort((a, b) => b.last_used_at - a.last_used_at)
+    const { total, page } = paginate(sorted, limit, offset)
+
+    // 只对当前页批量查轮数，避免 N+1
+    const convIds = page.map((s) => s.conversation_id)
+    const turnRows = convIds.length
+      ? await db.get('openai_chat', { conversation_id: convIds }, { fields: ['conversation_id', 'turn_number'] })
+      : []
+    const turnSet = new Map<string, Set<number>>()
+    for (const t of turnRows) {
+      const set = turnSet.get(t.conversation_id) ?? new Set<number>()
+      set.add(t.turn_number)
+      turnSet.set(t.conversation_id, set)
+    }
+
+    const out: SessionRow[] = page.map((s) => ({
+      conversationId: s.conversation_id,
+      title: s.user_first_msg || '(空)',
+      startedAt: s.started_at,
+      lastUsedAt: s.last_used_at,
+      isCurrent: s.conversation_id === currentConv,
+      isCompacted: !!s.prev_session_id,
+      turns: turnSet.get(s.conversation_id)?.size ?? 0,
+    }))
+    return { total, rows: out }
+  },
+  { authority: AUTH }
+)
+```
+
+同步更新 `declare module '@koishijs/console'` 里 search/sessions 的返回类型。
+
+- [ ] **Step 7: 前端接分页 + 「加载更多」** — `plugins/llm-admin/client/index.js`
+
+- `doSearch()`：`send('llm-admin/search', { q, limit: 50, offset: 0 })` → 存 `results.value = res.users`、`searchTotal = res.total`；结果列表底部若 `results.length < searchTotal` 显示「加载更多」按钮，点击 `offset += 50` 再 send 并 **append**。
+- `loadUser(id)`：`sessions` 改为 `{ total, rows }`；存 `sessions.value = res.rows`、`sessionTotal = res.total`；列表底部若 `sessions.length < sessionTotal` 显示「加载更多」，点击 `offset += 30` 再 send 并 **append**。
+
+（保持手写紧凑风；用 `ref` 存 offset/total。）
+
+- [ ] **Step 8: 跑测试 + 提交**
+
+Run: `npx vitest run plugins/llm-admin/__tests__`
+Expected: PASS
+
+```bash
+git add plugins/llm-admin/filters.ts plugins/llm-admin/__tests__/filters.test.ts plugins/llm-admin/index.ts plugins/llm-admin/client/index.js
+git commit -m "feat(llm-admin): paginate search & session list, fix sessions N+1"
+```
+
+（控制器 restart + 浏览器核对搜索/会话「加载更多」。）
+
+---
+
+### Task 3: 会话回放分页（聊天软件式无限上滚）
+
+**Files:**
+- Create: `plugins/llm-admin/turns.ts`
+- Create: `plugins/llm-admin/__tests__/turns.test.ts`
+- Modify: `plugins/llm-admin/index.ts`（session listener）
+- Modify: `plugins/llm-admin/client/index.js`（chat 定位底部 + 上滚加载）
+
+**Interfaces:**
+- Produces:
+  ```ts
+  // 从「已按 turn_number 升序去重的 turn 列表」里，取 < beforeTurn 的最近 limit 个 turn 的下界
+  export function turnWindow(
+    turnNumbers: number[], limit: number, beforeTurn: number | null
+  ): { fromTurn: number | null; hasMore: boolean }
+  ```
+- 事件签名：
+  ```ts
+  'llm-admin/session'(payload: { conversationId: string; limit?: number; beforeTurn?: number | null })
+    : { messages: ChatMsg[]; earliestTurn: number | null; hasMore: boolean }
+  ```
+
+- [ ] **Step 1: 写失败测试** — `plugins/llm-admin/__tests__/turns.test.ts`
+
+```ts
+import { describe, expect, it } from 'vitest'
+
+import { turnWindow } from '../turns'
+
+describe('turnWindow', () => {
+  const turns = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  it('takes the most recent `limit` turns when beforeTurn is null', () => {
+    expect(turnWindow(turns, 3, null)).toEqual({ fromTurn: 8, hasMore: true })
+  })
+  it('takes `limit` turns strictly before the cursor', () => {
+    expect(turnWindow(turns, 3, 8)).toEqual({ fromTurn: 5, hasMore: true })
+  })
+  it('clamps at the beginning and reports hasMore=false', () => {
+    expect(turnWindow(turns, 3, 3)).toEqual({ fromTurn: 1, hasMore: false })
+    expect(turnWindow(turns, 20, null)).toEqual({ fromTurn: 1, hasMore: false })
+  })
+  it('empty conversation', () => {
+    expect(turnWindow([], 3, null)).toEqual({ fromTurn: null, hasMore: false })
+  })
+})
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `npx vitest run plugins/llm-admin/__tests__/turns.test.ts`
+Expected: FAIL
+
+- [ ] **Step 3: 写实现** — `plugins/llm-admin/turns.ts`
+
+```ts
+// turnNumbers 已升序去重。返回本批要包含的最小 turn（fromTurn，含）与是否还有更早。
+export function turnWindow(
+  turnNumbers: number[],
+  limit: number,
+  beforeTurn: number | null
+): { fromTurn: number | null; hasMore: boolean } {
+  if (!turnNumbers.length) return { fromTurn: null, hasMore: false }
+  const eligible = beforeTurn == null ? turnNumbers : turnNumbers.filter((t) => t < beforeTurn)
+  if (!eligible.length) return { fromTurn: null, hasMore: false }
+  const startIdx = Math.max(0, eligible.length - limit)
+  return { fromTurn: eligible[startIdx], hasMore: startIdx > 0 }
+}
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `npx vitest run plugins/llm-admin/__tests__/turns.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: session listener 用 turnWindow** — `plugins/llm-admin/index.ts`
+
+```ts
+import { turnWindow } from './turns'
+// ...
+ctx.console.addListener(
+  'llm-admin/session',
+  async ({ conversationId, limit = 20, beforeTurn = null }) => {
+    // 该会话所有 turn_number（升序去重）
+    const allRows = await db.get('openai_chat', { conversation_id: conversationId }, { fields: ['turn_number'] })
+    const turns = [...new Set(allRows.map((r) => r.turn_number))].sort((a, b) => a - b)
+    const { fromTurn, hasMore } = turnWindow(turns, limit, beforeTurn)
+    if (fromTurn == null) return { messages: [], earliestTurn: null, hasMore: false }
+
+    const upper = beforeTurn == null ? Number.MAX_SAFE_INTEGER : beforeTurn
+    const rows = (await db.get(
+      'openai_chat',
+      { conversation_id: conversationId, turn_number: { $gte: fromTurn, $lt: upper } },
+      {
+        fields: ['role', 'content', 'reasoning_content', 'tool_calls', 'tool_name', 'time'],
+        sort: { turn_number: 'asc', intra_turn_seq: 'asc', id: 'asc' },
+      } as any
+    )) as unknown as Array<{
+      role: string; content: string; reasoning_content: string; tool_calls: string; tool_name: string; time: number
+    }>
+    const extractUser = (c: string) => {
+      const m = c.match(/<user_message>([\s\S]*?)<\/user_message>/)
+      return (m ? m[1] : c).trim()
+    }
+    const messages = rows.map((r): ChatMsg => {
+      if (r.role === 'user')
+        return { time: r.time, role: 'user', content: extractUser(r.content), raw: r.content }
+      if (r.role === 'system') return { time: r.time, role: 'system', content: r.content }
+      if (r.role === 'tool') return { time: r.time, role: 'tool', toolName: r.tool_name, content: r.content }
+      return {
+        time: r.time,
+        role: 'assistant',
+        content: r.content,
+        reasoning: r.reasoning_content || undefined,
+        toolCalls: r.tool_calls || undefined,
+      }
+    })
+    return { messages, earliestTurn: fromTurn, hasMore }
+  },
+  { authority: AUTH }
+)
+```
+
+（映射逻辑保留原型现有 `extractUser` + role 分支，含 user 的 `raw` envelope、assistant 的 `reasoning`/`toolCalls`、tool 的 `toolName`、每条 `time`。同步更新事件返回类型。）
+
+- [ ] **Step 6: 前端无限上滚** — `plugins/llm-admin/client/index.js`
+
+- 选中会话时 `send('llm-admin/session', { conversationId, limit: 20, beforeTurn: null })` → `msgs.value = res.messages`，存 `earliestTurn`/`hasMore`；渲染后 **`nextTick` 把滚动容器 scrollTop 设为 scrollHeight**（定位底部）。
+- 滚动容器监听 `scroll`：当 `scrollTop < 60` 且 `hasMore` 且非加载中 → `send({ conversationId, limit: 20, beforeTurn: earliestTurn })`，**prepend** `res.messages` 到 `msgs.value` 头部，更新 `earliestTurn`/`hasMore`；prepend 后**保持视觉位置**（记录 prepend 前 `scrollHeight`，prepend 后 `scrollTop += (新 scrollHeight - 旧 scrollHeight)`）。
+
+- [ ] **Step 7: 跑测试 + 提交**
+
+Run: `npx vitest run plugins/llm-admin/__tests__`
+Expected: PASS
+
+```bash
+git add plugins/llm-admin/turns.ts plugins/llm-admin/__tests__/turns.test.ts plugins/llm-admin/index.ts plugins/llm-admin/client/index.js
+git commit -m "feat(llm-admin): chat-app-style session replay pagination (infinite scroll up)"
+```
+
+（控制器 restart + 浏览器核对：打开定位底部、上滚加载更早、位置不跳。）
+
+---
+
+### Task 4: 记忆编辑器（写操作）
+
+**Files:**
+- Create: `plugins/llm-admin/memory-edit.ts`
+- Create: `plugins/llm-admin/__tests__/memory-edit.test.ts`
+- Modify: `plugins/llm-admin/index.ts`（memory-save / memory-clear listener）
+- Modify: `plugins/llm-admin/client/index.js`（总览内记忆编辑卡片）
+- Modify: `plugins/llm-admin/client/style.css`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export function utf8ByteLength(s: string): number
+  export function checkMemoryWrite(content: string, hardLimit: number): { ok: boolean; byteSize: number; error?: string }
+  ```
+- 事件：
+  ```ts
+  'llm-admin/memory-get'(payload: { id: number }): { content: string; byteSize: number; updateCount: number; lastUpdated: number | null; platform: string | null }
+  'llm-admin/memory-save'(payload: { id: number; content: string }): { ok: boolean; byteSize: number; error?: string }
+  'llm-admin/memory-clear'(payload: { id: number }): { ok: boolean }
+  ```
+
+- [ ] **Step 1: 写失败测试** — `plugins/llm-admin/__tests__/memory-edit.test.ts`
+
+```ts
+import { describe, expect, it } from 'vitest'
+
+import { checkMemoryWrite, utf8ByteLength } from '../memory-edit'
+
+describe('utf8ByteLength', () => {
+  it('counts ASCII and multibyte correctly', () => {
+    expect(utf8ByteLength('abc')).toBe(3)
+    expect(utf8ByteLength('中')).toBe(3) // UTF-8 中文 3 字节
+    expect(utf8ByteLength('')).toBe(0)
+  })
+})
+
+describe('checkMemoryWrite', () => {
+  it('accepts content within limit', () => {
+    expect(checkMemoryWrite('hello', 3300)).toEqual({ ok: true, byteSize: 5 })
+  })
+  it('rejects content over the byte limit', () => {
+    const r = checkMemoryWrite('中'.repeat(2000), 3300) // 6000 bytes
+    expect(r.ok).toBe(false)
+    expect(r.byteSize).toBe(6000)
+    expect(r.error).toMatch(/超出|limit|字节/)
+  })
+  it('accepts empty content (clear via save)', () => {
+    expect(checkMemoryWrite('', 3300)).toEqual({ ok: true, byteSize: 0 })
+  })
+})
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `npx vitest run plugins/llm-admin/__tests__/memory-edit.test.ts`
+Expected: FAIL
+
+- [ ] **Step 3: 写实现** — `plugins/llm-admin/memory-edit.ts`
+
+```ts
+export function utf8ByteLength(s: string): number {
+  return new TextEncoder().encode(s).length
+}
+
+export function checkMemoryWrite(
+  content: string,
+  hardLimit: number
+): { ok: boolean; byteSize: number; error?: string } {
+  const byteSize = utf8ByteLength(content)
+  if (byteSize > hardLimit)
+    return { ok: false, byteSize, error: `记忆超出字节上限（${byteSize} > ${hardLimit}）` }
+  return { ok: true, byteSize }
+}
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `npx vitest run plugins/llm-admin/__tests__/memory-edit.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: memory listeners** — `plugins/llm-admin/index.ts`
+
+记忆键：`user_id = String(id)`。读现有行拿 `platform`；写时保留 fork 节流元数据（`message_count_at_update` / `last_forked_conversation_id`）。硬上限 = `memoryByteLimit(默认3000) * 1.1`（对齐 llm 插件 `getMemoryHardLimit`）。
+
+```ts
+import { checkMemoryWrite, utf8ByteLength } from './memory-edit'
+// ...
+// 取该用户记忆行（user_id = String(id)）
+async function memoryRow(id: number) {
+  const rows = await db.get('openai_user_memory', { user_id: String(id) } as any, {} as any)
+  return (rows[0] as any) ?? null
+}
+async function memoryPlatform(id: number): Promise<string> {
+  const existing = await memoryRow(id)
+  if (existing?.platform) return existing.platform
+  // 无现有行：取首个 binding 平台归一化 onebot→qq
+  const b = await db.get('binding', { aid: id }, { fields: ['platform', 'bid'] })
+  const first = [...b].sort((x, y) => x.bid - y.bid)[0]
+  const p = first?.platform
+  return p === 'onebot' ? 'qq' : p || 'unknown'
+}
+
+ctx.console.addListener('llm-admin/memory-get', async ({ id }) => {
+  const row = await memoryRow(id)
+  return {
+    content: row?.content ?? '',
+    byteSize: row?.byte_size ?? 0,
+    updateCount: row?.update_count ?? 0,
+    lastUpdated: row?.last_updated_at ?? null,
+    platform: row?.platform ?? null,
+  }
+}, { authority: AUTH })
+
+ctx.console.addListener('llm-admin/memory-save', async ({ id, content }) => {
+  const hardLimit = Math.ceil((ctx.llm.config?.memoryByteLimit ?? 3000) * 1.1)
+  const check = checkMemoryWrite(content, hardLimit)
+  if (!check.ok) return check
+  const existing = await memoryRow(id)
+  const platform = existing?.platform ?? (await memoryPlatform(id))
+  await ctx.llm.memory.set(
+    platform,
+    String(id),
+    content,
+    existing?.message_count_at_update ?? 0,
+    existing?.last_forked_conversation_id ?? ''
+  )
+  return { ok: true, byteSize: utf8ByteLength(content) }
+}, { authority: AUTH })
+
+ctx.console.addListener('llm-admin/memory-clear', async ({ id }) => {
+  const platform = await memoryPlatform(id)
+  const ok = await ctx.llm.memory.delete(platform, String(id))
+  return { ok }
+}, { authority: AUTH })
+```
+
+> 实现者注意：`ctx.llm.memory.set` 参数顺序与 `getMemoryHardLimit`/`memoryByteLimit` 字段需以 `src/plugins/llm/services/memory.ts` + `index.tsx` 现况为准核对（本文件在 tsconfig include 外，类型噪音可接受，但**运行时参数必须对**）。**日志不得打印 content。**
+
+- [ ] **Step 6: 前端记忆编辑卡片**（右栏总览内）— `plugins/llm-admin/client/index.js` + `style.css`
+
+在 `overviewView(o)` 末尾追加一张 `k-card`「长期记忆」：进入总览时 `send('llm-admin/memory-get', { id })` 载入 → `textarea`（绑定 `memContent` ref）+ 实时 UTF-8 字节计数（用 `new TextEncoder().encode(v).length`）对 3300 上限、超限标红并禁用保存 + 「保存」（`memory-save` 成功后刷新计数）+ 「清空 ⚠」（`window.confirm('确认清空该用户长期记忆？')` 通过后 `memory-clear` + 清空 textarea）。样式加 `.la-mem-*`。
+
+- [ ] **Step 7: 跑测试 + 提交**
+
+Run: `npx vitest run plugins/llm-admin/__tests__`
+Expected: PASS
+
+```bash
+git add plugins/llm-admin/memory-edit.ts plugins/llm-admin/__tests__/memory-edit.test.ts plugins/llm-admin/index.ts plugins/llm-admin/client/index.js plugins/llm-admin/client/style.css
+git commit -m "feat(llm-admin): long-term memory editor (view/edit/clear)"
+```
+
+（控制器 restart + 在**测试用户**上核对读/改/清空落库 + 二次确认。）
+
+---
+
+### Task 5: 强制轮转 session（写操作）
+
+**Files:**
+- Modify: `plugins/llm-admin/index.ts`（rotate listener）
+- Modify: `plugins/llm-admin/client/index.js`（用户头「强制轮转」按钮）
+- Modify: `plugins/llm-admin/client/style.css`
+
+**Interfaces:**
+- 事件：`'llm-admin/rotate'(payload: { id: number }): { ok: true; conversationId: string }`
+
+- [ ] **Step 1: rotate listener** — `plugins/llm-admin/index.ts`
+
+纯新开：生成新 `conversation_id`，建 `openai_session`（不带 `prevSessionId`），置 `user.openai_last_conversation_id`，同步 `activeChats`。参数以 `src/plugins/llm/services/session-manager.ts` 的 `create` 签名 + `commands/chat.tsx:374-407` 轮转逻辑为准。
+
+```ts
+ctx.console.addListener('llm-admin/rotate', async ({ id }) => {
+  const newId = crypto.randomUUID()
+  const platform = await memoryPlatform(id) // 复用上面的平台解析
+  await ctx.llm.sessions.create({
+    conversationId: newId,
+    conversationOwner: id,
+    platform,
+    userId: String(id),
+    userFirstMsg: '(管理台强制轮转)',
+  })
+  await db.set('user', { id }, { openai_last_conversation_id: newId } as any)
+  const active = ctx.llm.activeChats?.get?.(id)
+  if (active) active.conversationId = newId
+  return { ok: true, conversationId: newId }
+}, { authority: AUTH })
+```
+
+> 实现者：先读 `session-manager.ts` 的 `CreateSessionInput` 字段名 + `activeChats` 的真实 API（get/set 结构）再定稿；**不要凭本片段猜**。日志不打印会话内容。
+
+- [ ] **Step 2: 前端轮转按钮** — `plugins/llm-admin/client/index.js` + `style.css`
+
+用户头区加「强制轮转 ⚠」按钮（`e.stopPropagation()` 防触发头部回总览）：`window.confirm('确认给该用户强制轮转 session？下条消息将从空白新会话开始。')` 通过后 `send('llm-admin/rotate', { id })`，成功后重新 `loadUser(id)` 刷新会话列表（新会话应标「当前」）。样式加 `.la-rotate`（警示色）。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add plugins/llm-admin/index.ts plugins/llm-admin/client/index.js plugins/llm-admin/client/style.css
+git commit -m "feat(llm-admin): force session rotation (fresh, no compaction)"
+```
+
+（控制器 restart + 在**测试用户**上核对：轮转后 openai_last_conversation_id 变、新会话入列标当前、旧会话仍在。**不在真实用户上测**。）
+
+---
+
+### Task 6: 收尾（格式化 + 类型声明整洁 + 全量核对）
+
+**Files:**
+- Modify: `plugins/llm-admin/index.ts`（`declare module` 事件签名与最终一致；prettier）
+- Modify: `plugins/llm-admin/aggregate-user.ts` / `filters.ts` / `turns.ts` / `memory-edit.ts`（prettier）
+
+- [ ] **Step 1: 核对 `declare module '@koishijs/console'`** 的 8 个事件签名（search / overview / sessions / session / memory-get / memory-save / memory-clear / rotate）与各 listener/前端 `send` 调用完全一致（payload 可选字段、返回结构）。
+
+- [ ] **Step 2: 只格式化本包后端 `.ts`（勿碰 client 手写 ESM）**
+
+```bash
+npx prettier --write plugins/llm-admin/index.ts plugins/llm-admin/aggregate-user.ts plugins/llm-admin/filters.ts plugins/llm-admin/turns.ts plugins/llm-admin/memory-edit.ts plugins/llm-admin/__tests__/*.ts
+```
+
+- [ ] **Step 3: 全量测试 + 提交**
+
+Run: `npx vitest run plugins/llm-admin/__tests__`
+Expected: PASS（aggregate-user 7 + filters 5 + turns 4 + memory-edit 6）
+
+```bash
+git add plugins/llm-admin
+git commit -m "chore(llm-admin): finalize event signatures + format backend"
+```
+
+---
+
+## 附：原型现状（各任务的起点）
+
+commit `94cdae7` 已含：`package.json`、`index.ts`（search/overview/sessions/session 四 listener，无分页）、`client/index.js`（vue-router query 路由 + 搜索/总览/会话列表/chat 回放 + 折叠 + 日期 + 原始 envelope + 可点头部）、`client/style.css`；`src/index.ts` 已注册 `PluginLlmAdmin`；workspace symlink + docker `./plugins` 挂载已就位。本计划在此之上：Task1 抽聚合、Task2 分页+N+1、Task3 回放分页、Task4 记忆编辑、Task5 轮转、Task6 收尾。

--- a/docs/superpowers/plans/2026-07-09-llm-admin.md
+++ b/docs/superpowers/plans/2026-07-09-llm-admin.md
@@ -304,16 +304,16 @@ import { describe, expect, it } from 'vitest'
 
 import { matchUser, paginate } from '../filters'
 
-const u = { id: 42, name: '爸爸', account: 'qq:824399619' }
+const u = { id: 42, name: '爸爸', account: 'qq:100863' }
 
 describe('matchUser', () => {
   it('matches exact #id and bare id', () => {
     expect(matchUser(u, '#42')).toBe(true)
     expect(matchUser(u, '42')).toBe(true)
-    expect(matchUser(u, '4')).toBe(false) // id 是精确匹配，不是子串
+    expect(matchUser(u, '4')).toBe(false) // id 精确匹配非子串；account/name 也不含 '4'，隔离该行为
   })
   it('matches account and name substrings, case-insensitive', () => {
-    expect(matchUser(u, '8243')).toBe(true)
+    expect(matchUser(u, '0086')).toBe(true)
     expect(matchUser(u, 'QQ:')).toBe(true)
     expect(matchUser(u, '爸')).toBe(true)
     expect(matchUser(u, 'zzz')).toBe(false)

--- a/docs/superpowers/specs/2026-07-09-llm-admin-design.md
+++ b/docs/superpowers/specs/2026-07-09-llm-admin-design.md
@@ -1,0 +1,120 @@
+# LLM 用户管理控制台 — 设计文档
+
+## 目标
+
+给 SILI 的 LLM 插件提供一个**按用户**的管理控制台（koishi console 页面）：搜索用户 → 查看该用户的用量总览、会话历史（chat 式回放）→ **管理其长期记忆**（改 / 清空）、**强制轮转其 session**。
+
+读侧已由原型 spike 验证（commit `94cdae7`）；本 spec 固化为带测试的正式实现，并补上分页、N+1 修复、写操作。
+
+## 非目标（YAGNI）
+
+- 不做跨用户批量操作、不做用户封禁/权限编辑。
+- 不渲染 system prompt——它请求时从进程内 memoize 的共享 builder 实时拼接、**不落库**，跨用户共享，无「这个用户这段对话」的信息。
+- 不做实时推送；打开时拉取 + 手动刷新 / 加载更多。
+- 不引入前端构建工具链。
+
+## 架构
+
+独立 workspace 子包 `plugins/llm-admin/`（`koishi-plugin-llm-admin`，未来可独立发包）：
+
+```
+plugins/llm-admin/
+├── package.json          # name: koishi-plugin-llm-admin
+├── index.ts              # 后端：listener 注册 + addEntry
+├── aggregate-user.ts     # 纯函数：单用户用量聚合（可单测）
+├── client/
+│   ├── index.js          # 手写 ESM：vue-router 路由 + Vue h() 渲染
+│   └── style.css
+└── __tests__/aggregate-user.test.ts
+```
+
+- `inject: ['console', 'database', 'llm']`。后端 TS 由 bun 直接跑、**不构建**；前端手写浏览器 ESM，console 原样 serve。
+- 复用仪表盘验证过的机制：伪包（`../vue.js` / `../client.js` / `../vue-router.js`）、`resolveComponent('k-layout'/'k-card')`、鉴权就绪门（首个 `send` 等 `store.user`）、`addEntry` 指向 `node_modules/koishi-plugin-llm-admin/client`（过 403 守卫）。
+- 已在 `src/index.ts` 的 console 注册块 `ctx.plugin(PluginLlmAdmin)`；生产 `docker-compose.yml` 的 `./plugins` 挂载已就位。
+
+## 权限与隐私（一等约束）
+
+- **authority 4（仅 sysop）** 门控**页面 + 全部 listener（含读）**。记忆/会话正文是隐私数据，读也要拦。（plugin-auth 的 `on("activity", n => n.authority>0 && user.authority<n.authority)` 钩子对 <4 用户隐藏侧栏入口 + router 拦导航；listener 的 `{ authority: 4 }` 拒绝数据请求。）
+- **服务端日志不落记忆/会话正文**，只记 id / 计数。
+- **破坏性写操作（清空记忆、强制轮转）UI 内二次确认**再发请求。
+- 会话回放**默认只拉最近 N 轮**（N=20），显式「加载更早」再往前——避免整段隐私历史一次性倾倒。
+- 前端不做持久化/缓存；数据按需拉取、只流向已鉴权的 sysop 会话。页面顶部常驻隐私提示条。
+
+## 数据模型（已查实）
+
+一切围绕 **koishi `user.id`** 对齐，选中用户后无需 binding 解析即可取其全部数据：
+
+| 概念 | 表 | 键 |
+|---|---|---|
+| 长期记忆 | `openai_user_memory` | `(platform, user_id)`，其中 `user_id = String(koishi user.id)`，`platform` 归一化（`onebot → 'qq'`） |
+| 会话 | `openai_session` | `conversation_id`；按 `conversation_owner`(= user.id) 查该用户所有会话 |
+| 消息历史 | `openai_chat` | 按 `conversation_id` 查，排序 **`(turn_number, intra_turn_seq, id)`**（`time` 是 wall-clock、不单调，不作排序键） |
+
+- `resolveMemoryKey(session)`：`platform = onebot?'qq':platform`，`userId = String(session.user.id)`。→ 后端无 session，按 `user_id = String(选中id)` 直接查记忆行；写时 platform 取现有行的 `platform`（无现有行则取该用户首个 binding 的 platform 归一化）。
+- user 行的 `content` 是完整 envelope（`<long_term_memory>?` + `<turn_context>` JSON + `<user_message>`）。回放时抽取 `<user_message>` 内层为正文，完整 envelope 放折叠。
+- token 聚合陷阱：`cachedTokens ⊂ promptTokens`、`reasoningTokens ⊂ completionTokens`，不重复计入 total；缺失 `?? 0`；`totalTokens` 缺省回退 `prompt+completion`。
+
+## 服务（`ctx.llm.*`）复用
+
+| 操作 | 复用 |
+|---|---|
+| 改记忆 | `ctx.llm.memory.getMeta(p,u)` 读；`ctx.llm.memory.set(p,u,content,msgCount,convId)` 写（`msgCount`/`convId` 传现有 meta 的 `message_count_at_update`/`last_forked_conversation_id` 以保留 fork 节流状态） |
+| 清空记忆 | `ctx.llm.memory.delete(p,u)` |
+| 会话历史 | 直接查 `openai_chat`（需要 reasoning/tool_calls/time 等字段，`chatHistory.getById` 的 turn 限制语义不完全匹配预览需求） |
+| 强制轮转 | `crypto.randomUUID()` + `ctx.llm.sessions.create({conversationId,conversationOwner,platform,userId,userFirstMsg:'(强制轮转)'})` + 置 `user.openai_last_conversation_id` + 同步 `ctx.llm.activeChats`（若有在飞缓存）。**纯新开、不压缩、不带 prev_session_id。** |
+
+## 后端 API（listener，全部 `authority: 4`）
+
+```ts
+'llm-admin/search'(payload: { q: string; limit?: number; offset?: number })
+  : { total: number; users: AdminUser[] }                 // #id 精确 / platform:pid 子串 / 昵称子串
+'llm-admin/overview'(payload: { id: number }): UserOverview | null   // 用量卡片 + 近30天趋势 + 模型分布 + 会话总数
+'llm-admin/sessions'(payload: { id: number; limit?: number; offset?: number })
+  : { total: number; rows: SessionRow[] }                 // 按 last_used_at 倒序；标当前活跃 / 压缩派生 / 轮数
+'llm-admin/session'(payload: { conversationId: string; limit?: number; beforeTurn?: number })
+  : { messages: ChatMsg[]; earliestTurn: number; hasMore: boolean }   // 最近 N 轮 + 加载更早
+'llm-admin/memory-get'(payload: { id: number }): { content: string; byteSize: number; updateCount: number; lastUpdated: number|null; platform: string|null }  // 读，供编辑器载入
+'llm-admin/memory-save'(payload: { id: number; content: string }): { ok: boolean; byteSize: number; error?: string }  // 写
+'llm-admin/memory-clear'(payload: { id: number }): { ok: boolean }                                  // 写
+'llm-admin/rotate'(payload: { id: number }): { ok: true; conversationId: string }                   // 写
+```
+
+`AdminUser = { id, name, account }`；`SessionRow = { conversationId, title, startedAt, lastUsedAt, isCurrent, isCompacted, turns }`；`UserOverview`、`ChatMsg` 见原型 `index.ts`（`ChatMsg` 含 `time`、user 带 `raw` envelope、assistant 带 `reasoning`/`toolCalls`、tool 带 `toolName`）。
+
+### 分页 & 性能
+
+- **search**：候选池（有过会话的用户）解析身份后过滤，`limit`(默认 50)/`offset` 切片 + `total`。
+- **sessions**：`limit`(默认 30)/`offset` + `total`；**修 N+1**——原型为每个会话单查一次轮数，改为只对当前页窗口查、或一次性按 `conversation_id ∈ 当前页` 批量查 `turn_number` 再分组。
+- **session**：按 `turn_number` 倒序取最近 `limit`(默认 20) 轮的行、再正序展示；`beforeTurn` 游标往前加载更早；返回 `hasMore` / `earliestTurn`。前端是**聊天软件式无限上滚**（见 UX），非按钮。
+
+## 前端 UX（vue-router query 路由，已由原型验证）
+
+单注册页 `/llm-admin`（`authority: 4`），用 `useRoute`/`useRouter` 的 query 做真实路由（`?user=<id>&session=<convId>`，可深链 / 后退）：
+
+- **无 user**：搜索视图（隐私提示条 + 表单 + 结果列表，点结果 `push({query:{user}})`）。
+- **有 user**：master-detail
+  - **左栏**：固定用户头（昵称 + platform:pid + #id，会话数 · 总 tok；**点击回总览**，即 drop session query；区内含「强制轮转 ⚠」按钮）+ 「返回搜索」+ **会话列表**（倒序、标题=首句、最后活跃 + 轮数、当前/压缩 badge、「加载更多」）。
+  - **右栏 · 无 session（总览视图）**：用量卡片（含输入/输出/缓存）+ 近30天趋势 SVG + 模型分布 + **记忆编辑器卡片**。
+  - **右栏 · 有 session**：**chat 式回放（聊天软件式）**——用户气泡右 / SILI 气泡左 / 工具紧凑折叠；**默认折叠**：`💭 思维链`、`🔧 调用 <工具名>`、`🔧 <工具名> 结果`、`📄 原始 envelope`；每气泡下小号日期。**打开定位到底部（最新）**，**向上滚动到近顶部自动加载更早**（prepend + 保持滚动位置，无限上滚），`hasMore=false` 停。
+- **记忆编辑器卡片**（右栏总览内）：textarea 载入现有记忆 + 字节计数（对 `memoryByteLimit`，默认 3000，超限拦保存）+ 「保存」+「清空 ⚠」（二次确认）。
+- **强制轮转**：左栏用户头区「强制轮转 ⚠」按钮，二次确认后 `rotate`，成功刷新会话列表。
+
+## 测试
+
+- **纯函数单测**（`aggregate-user.ts` 抽出原型内联的聚合）：单用户 token 数学（in/out/cached 不重复计）、近30天趋势按天分桶、模型分布排序。
+- 搜索三路匹配（#id / pid / name）、分页切片（limit/offset/total）、会话回放 turn 窗口切分、记忆 platform 键归一化（`onebot→qq`）——可测的纯逻辑抽出单测。
+- listener 薄封装 + 写操作：浏览器实机验证（真实数据）；写操作在**测试用户**上验证真实落库 + 二次确认流程。
+
+## 部署
+
+- 无构建：手写 ESM 直接 serve，`git pull` + restart 生效。
+- workspace 成员进 `bun.lock`，容器 `bun install --frozen-lockfile` 建 symlink。首次部署走 `docker compose up -d core`（`./plugins` 挂载已在 compose 中）。
+
+## 已决
+
+- 位置：**独立包** `plugins/llm-admin`。入口：仪表盘 TOP 用户可跳 + 本页搜索。
+- 权限：**authority 4 仅 sysop**，读也拦。
+- 轮转语义：**纯新开**（丢上下文，不压缩）。
+- session 预览：**会话列表 + 点任意一条回放**。
+- 路由：**vue-router query 真实路由**（非内存态）。
+- 分页：sessions/search 用 limit/offset+total；replay 最近 N 轮 + 加载更早；修 sessions N+1。

--- a/plugins/llm-admin/__tests__/aggregate-user.test.ts
+++ b/plugins/llm-admin/__tests__/aggregate-user.test.ts
@@ -7,14 +7,30 @@ const now = 1_752_000_000_000
 const idt = { id: 1, name: 'Alice', account: 'qq:100' }
 
 function row(p: Partial<UserUsageRow> = {}): UserUsageRow {
-  return { time: now - DAY, model: 'gpt-4o', usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 }, ...p }
+  return {
+    time: now - DAY,
+    model: 'gpt-4o',
+    usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
+    ...p,
+  }
 }
 
 describe('aggregateUserOverview', () => {
   it('sums tokens without double-counting cached', () => {
     const o = aggregateUserOverview(
-      [row({ usage: { promptTokens: 200, completionTokens: 100, totalTokens: 300, cachedTokens: 80 } })],
-      3, idt, now
+      [
+        row({
+          usage: {
+            promptTokens: 200,
+            completionTokens: 100,
+            totalTokens: 300,
+            cachedTokens: 80,
+          },
+        }),
+      ],
+      3,
+      idt,
+      now
     )
     expect(o.calls).toBe(1)
     expect(o.totalTokens).toBe(300)
@@ -28,7 +44,12 @@ describe('aggregateUserOverview', () => {
   })
 
   it('falls back total = prompt + completion when totalTokens missing', () => {
-    const o = aggregateUserOverview([row({ usage: { promptTokens: 30, completionTokens: 20 } })], 0, idt, now)
+    const o = aggregateUserOverview(
+      [row({ usage: { promptTokens: 30, completionTokens: 20 } })],
+      0,
+      idt,
+      now
+    )
     expect(o.totalTokens).toBe(50)
   })
 
@@ -45,14 +66,21 @@ describe('aggregateUserOverview', () => {
         row({ model: 'b', usage: { totalTokens: 500 } }),
         row({ model: 'a', usage: { totalTokens: 100 } }),
       ],
-      0, idt, now
+      0,
+      idt,
+      now
     )
     expect(o.models[0]).toEqual({ model: 'b', calls: 1, totalTokens: 500 })
     expect(o.models[1]).toEqual({ model: 'a', calls: 2, totalTokens: 200 })
   })
 
   it('tracks first/last active', () => {
-    const o = aggregateUserOverview([row({ time: now - 5 * DAY }), row({ time: now - DAY })], 0, idt, now)
+    const o = aggregateUserOverview(
+      [row({ time: now - 5 * DAY }), row({ time: now - DAY })],
+      0,
+      idt,
+      now
+    )
     expect(o.firstActive).toBe(now - 5 * DAY)
     expect(o.lastActive).toBe(now - DAY)
   })

--- a/plugins/llm-admin/__tests__/aggregate-user.test.ts
+++ b/plugins/llm-admin/__tests__/aggregate-user.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+
+import { type UserUsageRow, aggregateUserOverview } from '../aggregate-user'
+
+const DAY = 86_400_000
+const now = 1_752_000_000_000
+const idt = { id: 1, name: 'Alice', account: 'qq:100' }
+
+function row(p: Partial<UserUsageRow> = {}): UserUsageRow {
+  return { time: now - DAY, model: 'gpt-4o', usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 }, ...p }
+}
+
+describe('aggregateUserOverview', () => {
+  it('sums tokens without double-counting cached', () => {
+    const o = aggregateUserOverview(
+      [row({ usage: { promptTokens: 200, completionTokens: 100, totalTokens: 300, cachedTokens: 80 } })],
+      3, idt, now
+    )
+    expect(o.calls).toBe(1)
+    expect(o.totalTokens).toBe(300)
+    expect(o.promptTokens).toBe(200)
+    expect(o.completionTokens).toBe(100)
+    expect(o.cachedTokens).toBe(80)
+    expect(o.sessionCount).toBe(3)
+    expect(o.id).toBe(1)
+    expect(o.name).toBe('Alice')
+    expect(o.account).toBe('qq:100')
+  })
+
+  it('falls back total = prompt + completion when totalTokens missing', () => {
+    const o = aggregateUserOverview([row({ usage: { promptTokens: 30, completionTokens: 20 } })], 0, idt, now)
+    expect(o.totalTokens).toBe(50)
+  })
+
+  it('handles null usage without throwing', () => {
+    const o = aggregateUserOverview([row({ usage: null })], 0, idt, now)
+    expect(o.calls).toBe(1)
+    expect(o.totalTokens).toBe(0)
+  })
+
+  it('ranks models by total tokens desc', () => {
+    const o = aggregateUserOverview(
+      [
+        row({ model: 'a', usage: { totalTokens: 100 } }),
+        row({ model: 'b', usage: { totalTokens: 500 } }),
+        row({ model: 'a', usage: { totalTokens: 100 } }),
+      ],
+      0, idt, now
+    )
+    expect(o.models[0]).toEqual({ model: 'b', calls: 1, totalTokens: 500 })
+    expect(o.models[1]).toEqual({ model: 'a', calls: 2, totalTokens: 200 })
+  })
+
+  it('tracks first/last active', () => {
+    const o = aggregateUserOverview([row({ time: now - 5 * DAY }), row({ time: now - DAY })], 0, idt, now)
+    expect(o.firstActive).toBe(now - 5 * DAY)
+    expect(o.lastActive).toBe(now - DAY)
+  })
+
+  it('builds a continuous daily trend over rangeDays whose length covers the window', () => {
+    const o = aggregateUserOverview([row({ time: now - DAY })], 0, idt, now, 30)
+    expect(o.trend.length).toBeGreaterThanOrEqual(30)
+    const keys = new Set(o.trend.map((d) => d.date))
+    expect(keys.size).toBe(o.trend.length) // no duplicate days
+  })
+
+  it('leaves overview zeroed for a user with no rows', () => {
+    const o = aggregateUserOverview([], 0, idt, now)
+    expect(o.calls).toBe(0)
+    expect(o.firstActive).toBeNull()
+    expect(o.models).toEqual([])
+  })
+})

--- a/plugins/llm-admin/__tests__/filters.test.ts
+++ b/plugins/llm-admin/__tests__/filters.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { matchUser, paginate } from '../filters'
+
+const u = { id: 42, name: '爸爸', account: 'qq:100863' }
+
+describe('matchUser', () => {
+  it('matches exact #id and bare id', () => {
+    expect(matchUser(u, '#42')).toBe(true)
+    expect(matchUser(u, '42')).toBe(true)
+    expect(matchUser(u, '4')).toBe(false) // id 精确匹配非子串；account/name 也不含 '4'，隔离该行为
+  })
+  it('matches account and name substrings, case-insensitive', () => {
+    expect(matchUser(u, '0086')).toBe(true)
+    expect(matchUser(u, 'QQ:')).toBe(true)
+    expect(matchUser(u, '爸')).toBe(true)
+    expect(matchUser(u, 'zzz')).toBe(false)
+  })
+  it('empty query matches all', () => {
+    expect(matchUser(u, '')).toBe(true)
+    expect(matchUser(u, '  ')).toBe(true)
+  })
+})
+
+describe('paginate', () => {
+  const arr = [1, 2, 3, 4, 5]
+  it('returns total and the requested window', () => {
+    expect(paginate(arr, 2, 0)).toEqual({ total: 5, page: [1, 2] })
+    expect(paginate(arr, 2, 2)).toEqual({ total: 5, page: [3, 4] })
+    expect(paginate(arr, 2, 4)).toEqual({ total: 5, page: [5] })
+  })
+  it('offset past end yields empty page but real total', () => {
+    expect(paginate(arr, 2, 10)).toEqual({ total: 5, page: [] })
+  })
+})

--- a/plugins/llm-admin/__tests__/memory-edit.test.ts
+++ b/plugins/llm-admin/__tests__/memory-edit.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { checkMemoryWrite, utf8ByteLength } from '../memory-edit'
+
+describe('utf8ByteLength', () => {
+  it('counts ASCII and multibyte correctly', () => {
+    expect(utf8ByteLength('abc')).toBe(3)
+    expect(utf8ByteLength('中')).toBe(3) // UTF-8 中文 3 字节
+    expect(utf8ByteLength('')).toBe(0)
+  })
+})
+
+describe('checkMemoryWrite', () => {
+  it('accepts content within limit', () => {
+    expect(checkMemoryWrite('hello', 3300)).toEqual({ ok: true, byteSize: 5 })
+  })
+  it('rejects content over the byte limit', () => {
+    const r = checkMemoryWrite('中'.repeat(2000), 3300) // 6000 bytes
+    expect(r.ok).toBe(false)
+    expect(r.byteSize).toBe(6000)
+    expect(r.error).toMatch(/超出|limit|字节/)
+  })
+  it('accepts empty content (clear via save)', () => {
+    expect(checkMemoryWrite('', 3300)).toEqual({ ok: true, byteSize: 0 })
+  })
+})

--- a/plugins/llm-admin/__tests__/turns.test.ts
+++ b/plugins/llm-admin/__tests__/turns.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+
+import { turnWindow } from '../turns'
+
+describe('turnWindow', () => {
+  const turns = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  it('takes the most recent `limit` turns when beforeTurn is null', () => {
+    expect(turnWindow(turns, 3, null)).toEqual({ fromTurn: 8, hasMore: true })
+  })
+  it('takes `limit` turns strictly before the cursor', () => {
+    expect(turnWindow(turns, 3, 8)).toEqual({ fromTurn: 5, hasMore: true })
+  })
+  it('clamps at the beginning and reports hasMore=false', () => {
+    expect(turnWindow(turns, 3, 3)).toEqual({ fromTurn: 1, hasMore: false })
+    expect(turnWindow(turns, 20, null)).toEqual({ fromTurn: 1, hasMore: false })
+  })
+  it('empty conversation', () => {
+    expect(turnWindow([], 3, null)).toEqual({ fromTurn: null, hasMore: false })
+  })
+})

--- a/plugins/llm-admin/aggregate-user.ts
+++ b/plugins/llm-admin/aggregate-user.ts
@@ -34,7 +34,12 @@ function tok(u: Usage | null) {
   const prompt = u?.promptTokens ?? 0
   const completion = u?.completionTokens ?? 0
   const cached = u?.cachedTokens ?? 0
-  return { prompt, completion, cached, total: u?.totalTokens ?? prompt + completion }
+  return {
+    prompt,
+    completion,
+    cached,
+    total: u?.totalTokens ?? prompt + completion,
+  }
 }
 
 function localDate(time: number): string {
@@ -59,7 +64,10 @@ export function aggregateUserOverview(
   let lastActive: number | null = null
   const byModel = new Map<string, { calls: number; totalTokens: number }>()
   const since = now - rangeDays * DAY
-  const byDay = new Map<string, { promptTokens: number; completionTokens: number }>()
+  const byDay = new Map<
+    string,
+    { promptTokens: number; completionTokens: number }
+  >()
 
   for (const r of rows) {
     const t = tok(r.usage)
@@ -83,9 +91,16 @@ export function aggregateUserOverview(
   }
 
   const trend: UserOverview['trend'] = []
-  for (let d = new Date(since); d.getTime() <= now; d.setDate(d.getDate() + 1)) {
+  for (
+    let d = new Date(since);
+    d.getTime() <= now;
+    d.setDate(d.getDate() + 1)
+  ) {
     const key = localDate(d.getTime())
-    trend.push({ date: key, ...(byDay.get(key) ?? { promptTokens: 0, completionTokens: 0 }) })
+    trend.push({
+      date: key,
+      ...(byDay.get(key) ?? { promptTokens: 0, completionTokens: 0 }),
+    })
   }
 
   return {

--- a/plugins/llm-admin/aggregate-user.ts
+++ b/plugins/llm-admin/aggregate-user.ts
@@ -1,0 +1,106 @@
+export interface Usage {
+  promptTokens?: number
+  completionTokens?: number
+  totalTokens?: number
+  cachedTokens?: number
+}
+export interface UserUsageRow {
+  time: number
+  model: string
+  usage: Usage | null
+}
+export interface UserIdentity {
+  id: number
+  name: string
+  account: string
+}
+export interface UserOverview extends UserIdentity {
+  sessionCount: number
+  firstActive: number | null
+  lastActive: number | null
+  calls: number
+  totalTokens: number
+  promptTokens: number
+  completionTokens: number
+  cachedTokens: number
+  models: Array<{ model: string; calls: number; totalTokens: number }>
+  trend: Array<{ date: string; promptTokens: number; completionTokens: number }>
+}
+
+const DAY = 86_400_000
+
+// cachedTokens ⊂ promptTokens — 展示用，不计入 total。
+function tok(u: Usage | null) {
+  const prompt = u?.promptTokens ?? 0
+  const completion = u?.completionTokens ?? 0
+  const cached = u?.cachedTokens ?? 0
+  return { prompt, completion, cached, total: u?.totalTokens ?? prompt + completion }
+}
+
+function localDate(time: number): string {
+  const d = new Date(time)
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${d.getFullYear()}-${m}-${day}`
+}
+
+export function aggregateUserOverview(
+  rows: UserUsageRow[],
+  sessionCount: number,
+  identity: UserIdentity,
+  now: number,
+  rangeDays = 30
+): UserOverview {
+  let totalTokens = 0
+  let promptTokens = 0
+  let completionTokens = 0
+  let cachedTokens = 0
+  let firstActive: number | null = null
+  let lastActive: number | null = null
+  const byModel = new Map<string, { calls: number; totalTokens: number }>()
+  const since = now - rangeDays * DAY
+  const byDay = new Map<string, { promptTokens: number; completionTokens: number }>()
+
+  for (const r of rows) {
+    const t = tok(r.usage)
+    totalTokens += t.total
+    promptTokens += t.prompt
+    completionTokens += t.completion
+    cachedTokens += t.cached
+    if (firstActive === null || r.time < firstActive) firstActive = r.time
+    if (lastActive === null || r.time > lastActive) lastActive = r.time
+    const m = byModel.get(r.model) ?? { calls: 0, totalTokens: 0 }
+    m.calls += 1
+    m.totalTokens += t.total
+    byModel.set(r.model, m)
+    if (r.time >= since) {
+      const key = localDate(r.time)
+      const b = byDay.get(key) ?? { promptTokens: 0, completionTokens: 0 }
+      b.promptTokens += t.prompt
+      b.completionTokens += t.completion
+      byDay.set(key, b)
+    }
+  }
+
+  const trend: UserOverview['trend'] = []
+  for (let d = new Date(since); d.getTime() <= now; d.setDate(d.getDate() + 1)) {
+    const key = localDate(d.getTime())
+    trend.push({ date: key, ...(byDay.get(key) ?? { promptTokens: 0, completionTokens: 0 }) })
+  }
+
+  return {
+    ...identity,
+    sessionCount,
+    firstActive,
+    lastActive,
+    calls: rows.length,
+    totalTokens,
+    promptTokens,
+    completionTokens,
+    cachedTokens,
+    models: [...byModel.entries()]
+      .map(([model, v]) => ({ model, ...v }))
+      .sort((a, b) => b.totalTokens - a.totalTokens),
+    trend,
+  }
+}

--- a/plugins/llm-admin/client/index.js
+++ b/plugins/llm-admin/client/index.js
@@ -1,6 +1,6 @@
 import { defineComponent, h, nextTick, onMounted, onUnmounted, ref, resolveComponent, watch } from '../vue.js'
 import { useRoute, useRouter } from '../vue-router.js'
-import { send, store } from '../client.js'
+import { icons, send, store } from '../client.js'
 
 function fmt(n) {
   return (n ?? 0).toLocaleString('en-US')
@@ -697,11 +697,20 @@ const Admin = defineComponent({
 })
 
 export default (ctx) => {
+  // 侧栏图标：人形（用户管理），与用量仪表盘的柱状图区分
+  icons.register('llm-admin-users', {
+    render: () =>
+      h('svg', { viewBox: '0 0 24 24', fill: 'currentColor', xmlns: 'http://www.w3.org/2000/svg' }, [
+        h('circle', { cx: 12, cy: 7.5, r: 4.5 }),
+        h('path', { d: 'M3.5 21 a8.5 8.5 0 0 1 17 0 z' }),
+      ]),
+  })
   ctx.page({
     path: '/llm-admin',
     name: 'LLM 用户管理',
     authority: 4,
     order: 90,
+    icon: 'llm-admin-users',
     component: Admin,
   })
 }

--- a/plugins/llm-admin/client/index.js
+++ b/plugins/llm-admin/client/index.js
@@ -1,0 +1,354 @@
+import { defineComponent, h, onMounted, ref, resolveComponent, watch } from '../vue.js'
+import { useRoute, useRouter } from '../vue-router.js'
+import { send, store } from '../client.js'
+
+function fmt(n) {
+  return (n ?? 0).toLocaleString('en-US')
+}
+function fmtShort(n) {
+  n = n ?? 0
+  if (n >= 1e6) return (n / 1e6).toFixed(2).replace(/\.?0+$/, '') + 'M'
+  if (n >= 1e3) return (n / 1e3).toFixed(1).replace(/\.?0+$/, '') + 'k'
+  return String(Math.round(n))
+}
+function when(ts) {
+  if (!ts) return '—'
+  const d = new Date(ts)
+  const p = (x) => String(x).padStart(2, '0')
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}`
+}
+function ident(u) {
+  const parts = []
+  if (u?.name) parts.push(h('span', { class: 'la-nick' }, u.name))
+  if (u?.account) parts.push(h('span', { class: 'la-acct' }, u.account))
+  parts.push(h('span', { class: 'la-uid' }, `(#${u?.id ?? '?'})`))
+  return parts
+}
+function toolNames(json) {
+  try {
+    const arr = JSON.parse(json)
+    const names = (Array.isArray(arr) ? arr : [])
+      .map((t) => t?.function?.name || t?.name)
+      .filter(Boolean)
+    return names.join(', ') || '工具'
+  } catch {
+    return '工具'
+  }
+}
+function prettyJson(json) {
+  try {
+    return JSON.stringify(JSON.parse(json), null, 2)
+  } catch {
+    return json
+  }
+}
+function fold(cls, summary, body) {
+  return h('details', { class: 'la-fold ' + cls }, [
+    h('summary', {}, summary),
+    h('pre', {}, body),
+  ])
+}
+
+function trendSvg(trend) {
+  const W = 720
+  const H = 160
+  const pad = { l: 6, r: 6, t: 10, b: 6 }
+  const n = trend.length
+  const max = Math.max(1, ...trend.map((d) => d.promptTokens + d.completionTokens))
+  const iw = W - pad.l - pad.r
+  const ih = H - pad.t - pad.b
+  const x = (i) => pad.l + (n <= 1 ? iw / 2 : (i / (n - 1)) * iw)
+  const y = (v) => pad.t + ih - (v / max) * ih
+  const p = trend.map((d, i) => `${x(i)},${y(d.promptTokens)}`)
+  const t = trend.map((d, i) => `${x(i)},${y(d.promptTokens + d.completionTokens)}`)
+  const base = `${pad.l + iw},${pad.t + ih} ${pad.l},${pad.t + ih}`
+  return `<svg viewBox="0 0 ${W} ${H}" width="100%" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg"><polygon points="${t.join(' ')} ${base}" fill="var(--k-color-primary,#6a5acd)" fill-opacity="0.18"/><polygon points="${p.join(' ')} ${base}" fill="var(--k-color-primary,#6a5acd)" fill-opacity="0.35"/><polyline points="${t.join(' ')}" fill="none" stroke="var(--k-color-primary,#6a5acd)" stroke-width="1.5"/></svg>`
+}
+
+function overviewView(o) {
+  const KCard = resolveComponent('k-card')
+  const cards = [
+    { label: '调用次数', v: fmt(o.calls) },
+    {
+      label: '总 Token',
+      v: fmt(o.totalTokens),
+      sub: `输入 ${fmtShort(o.promptTokens)} · 输出 ${fmtShort(o.completionTokens)} · 缓存 ${fmtShort(o.cachedTokens)}`,
+    },
+    { label: '会话数', v: fmt(o.sessionCount) },
+    { label: '活跃区间', v: '', sub: `${when(o.firstActive)} ~ ${when(o.lastActive)}` },
+  ]
+  const first = o.trend[0]?.date ?? ''
+  const last = o.trend[o.trend.length - 1]?.date ?? ''
+  return h('div', { class: 'la-overview' }, [
+    h(
+      'div',
+      { class: 'la-cards' },
+      cards.map((c) =>
+        h('div', { class: 'la-card' }, [
+          h('div', { class: 'la-card-label' }, c.label),
+          c.v ? h('div', { class: 'la-card-value' }, c.v) : null,
+          c.sub ? h('div', { class: 'la-card-sub' }, c.sub) : null,
+        ])
+      )
+    ),
+    h(KCard, { class: 'la-panel' }, {
+      default: () => [
+        h('div', { class: 'la-panel-title' }, '近 30 天用量趋势'),
+        h('div', { class: 'la-chart', innerHTML: trendSvg(o.trend) }),
+        h('div', { class: 'la-chart-axis' }, [h('span', {}, first), h('span', {}, last)]),
+      ],
+    }),
+    h(KCard, { class: 'la-panel' }, {
+      default: () => [
+        h('div', { class: 'la-panel-title' }, '模型分布'),
+        o.models.length
+          ? h(
+              'div',
+              { class: 'la-models' },
+              o.models.map((m) =>
+                h('div', { class: 'la-model-row' }, [
+                  h('span', {}, m.model),
+                  h('span', { class: 'la-dim' }, `${fmtShort(m.totalTokens)} tok · ${fmt(m.calls)} 次`),
+                ])
+              )
+            )
+          : h('p', { class: 'la-dim' }, '（无数据）'),
+      ],
+    }),
+  ])
+}
+
+function renderMsg(m) {
+  if (m.role === 'tool') {
+    // 工具结果：吵，默认折叠
+    return h('div', { class: 'la-msg la-msg-tool' }, [
+      fold('la-tool', `🔧 ${m.toolName || '工具'} 结果`, m.content),
+    ])
+  }
+  const kids = []
+  if (m.role === 'assistant' && m.reasoning)
+    kids.push(fold('la-reasoning', '💭 思维链', m.reasoning))
+  if (m.content) kids.push(h('div', { class: 'la-msg-text' }, m.content))
+  if (m.role === 'user' && m.raw && m.raw !== m.content)
+    kids.push(fold('la-envelope', '📄 原始 envelope', m.raw))
+  if (m.role === 'assistant' && m.toolCalls)
+    kids.push(fold('la-tool', `🔧 调用 ${toolNames(m.toolCalls)}`, prettyJson(m.toolCalls)))
+  const label = m.role === 'user' ? '用户' : m.role === 'assistant' ? 'SILI' : m.role
+  return h('div', { class: `la-msg la-msg-${m.role}` }, [
+    h('div', { class: 'la-msg-role' }, label),
+    h('div', { class: 'la-bubble' }, kids),
+    h('div', { class: 'la-msg-time' }, when(m.time)),
+  ])
+}
+
+function chatView(msgs) {
+  if (msgs === null) return h('div', { class: 'la-dim la-chat-empty' }, '加载中…')
+  if (!msgs.length) return h('div', { class: 'la-dim la-chat-empty' }, '（空会话）')
+  return h('div', { class: 'la-chat' }, msgs.map(renderMsg))
+}
+
+const Admin = defineComponent({
+  name: 'LlmAdmin',
+  setup() {
+    const route = useRoute()
+    const router = useRouter()
+
+    const q = ref('')
+    const results = ref(null)
+    const searching = ref(false)
+    const overview = ref(null)
+    const sessions = ref(null)
+    const msgs = ref(null)
+    const err = ref('')
+    const ready = ref(false)
+
+    const uid = () => (route.query.user ? Number(route.query.user) : null)
+    const cid = () => route.query.session || null
+
+    async function doSearch() {
+      searching.value = true
+      err.value = ''
+      try {
+        results.value = await send('llm-admin/search', { q: q.value })
+      } catch (e) {
+        err.value = e?.message ?? String(e)
+      } finally {
+        searching.value = false
+      }
+    }
+
+    const openUser = (id) => router.push({ path: '/llm-admin', query: { user: id } })
+    const openSession = (conv) =>
+      router.push({ path: '/llm-admin', query: { user: uid(), session: conv } })
+    const backToOverview = () => {
+      if (cid()) router.push({ path: '/llm-admin', query: { user: uid() } })
+    }
+    const goSearch = () => router.push({ path: '/llm-admin', query: {} })
+
+    let loadedUser = null
+    let loadedConv = null
+    async function loadUser(id) {
+      overview.value = null
+      sessions.value = null
+      try {
+        overview.value = await send('llm-admin/overview', { id })
+        sessions.value = await send('llm-admin/sessions', { id })
+      } catch (e) {
+        err.value = e?.message ?? String(e)
+      }
+    }
+    async function loadSession(conv) {
+      msgs.value = null
+      try {
+        msgs.value = await send('llm-admin/session', { conversationId: conv })
+      } catch (e) {
+        err.value = e?.message ?? String(e)
+      }
+    }
+
+    // 路由驱动的数据加载（真实 URL：?user=&session=）
+    watch(
+      () => [ready.value, route.query.user, route.query.session],
+      () => {
+        if (!ready.value) return
+        const u = uid()
+        const c = cid()
+        if (u == null) {
+          loadedUser = loadedConv = null
+          overview.value = sessions.value = msgs.value = null
+          return
+        }
+        if (loadedUser !== u) {
+          loadedUser = u
+          loadUser(u)
+        }
+        if (c) {
+          if (loadedConv !== c) {
+            loadedConv = c
+            loadSession(c)
+          }
+        } else {
+          loadedConv = null
+          msgs.value = null
+        }
+      },
+      { immediate: true }
+    )
+
+    onMounted(() => {
+      if (store.user) ready.value = true
+      else {
+        const stop = watch(
+          () => store.user,
+          (u) => {
+            if (u) {
+              stop()
+              ready.value = true
+            }
+          }
+        )
+      }
+    })
+
+    function searchView() {
+      return h('div', { class: 'la-search' }, [
+        h('div', { class: 'la-notice' }, '⚠ 含用户隐私数据（长期记忆 / 会话正文）· 仅 sysop 可见'),
+        h('form', { class: 'la-search-form', onSubmit: (e) => { e.preventDefault(); doSearch() } }, [
+          h('input', {
+            class: 'la-input',
+            placeholder: '搜索用户： #id / platform:pid / 昵称（留空列全部）',
+            value: q.value,
+            onInput: (e) => (q.value = e.target.value),
+          }),
+          h('button', { class: 'la-btn', type: 'submit', disabled: searching.value }, searching.value ? '搜索中…' : '搜索'),
+        ]),
+        err.value ? h('div', { class: 'la-err' }, err.value) : null,
+        results.value === null
+          ? h('p', { class: 'la-dim' }, '输入后搜索，或留空点搜索列出全部聊过的用户。')
+          : results.value.length
+            ? h(
+                'div',
+                { class: 'la-result-list' },
+                results.value.map((u) =>
+                  h('div', { class: 'la-result', onClick: () => openUser(u.id) }, ident(u))
+                )
+              )
+            : h('p', { class: 'la-dim' }, '（无匹配用户）'),
+      ])
+    }
+
+    function detailView() {
+      const o = overview.value
+      const inSession = !!cid()
+      const headIdent = o || { id: uid() }
+      const left = h('div', { class: 'la-left' }, [
+        h(
+          'div',
+          {
+            class: ['la-user-head', inSession ? 'clickable' : ''],
+            title: inSession ? '点此返回用户总览' : '',
+            onClick: backToOverview,
+          },
+          [
+            h('button', { class: 'la-back', onClick: (e) => { e.stopPropagation(); goSearch() } }, '← 返回搜索'),
+            h('div', { class: 'la-user-ident' }, ident(headIdent)),
+            h('div', { class: 'la-user-meta' }, o ? `${o.sessionCount} 个会话 · ${fmtShort(o.totalTokens)} tok` : '加载中…'),
+            inSession ? h('div', { class: 'la-user-hint' }, '← 点此看用户总览') : null,
+          ]
+        ),
+        h('div', { class: 'la-session-list' },
+          sessions.value === null
+            ? [h('p', { class: 'la-dim' }, '加载中…')]
+            : sessions.value.length
+              ? sessions.value.map((s) =>
+                  h(
+                    'div',
+                    {
+                      class: ['la-session', cid() === s.conversationId ? 'active' : ''],
+                      onClick: () => openSession(s.conversationId),
+                    },
+                    [
+                      h('div', { class: 'la-session-title' }, [
+                        s.isCurrent ? h('span', { class: 'la-badge la-badge-cur' }, '当前') : null,
+                        s.isCompacted ? h('span', { class: 'la-badge' }, '压缩') : null,
+                        h('span', {}, s.title),
+                      ]),
+                      h('div', { class: 'la-session-meta' }, `${when(s.lastUsedAt)} · ${s.turns} 轮`),
+                    ]
+                  )
+                )
+              : [h('p', { class: 'la-dim' }, '（无会话）')]
+        ),
+      ])
+      const right = h('div', { class: 'la-right' }, [
+        err.value ? h('div', { class: 'la-err' }, err.value) : null,
+        inSession
+          ? chatView(msgs.value)
+          : o
+            ? overviewView(o)
+            : h('div', { class: 'la-dim' }, '加载中…'),
+      ])
+      return h('div', { class: 'la-detail' }, [left, right])
+    }
+
+    return () => {
+      const KLayout = resolveComponent('k-layout')
+      const body = !ready.value
+        ? h('div', { class: 'la-dim' }, '鉴权中…')
+        : uid() != null
+          ? detailView()
+          : searchView()
+      return h(KLayout, null, { default: () => h('div', { class: 'la-root' }, [body]) })
+    }
+  },
+})
+
+export default (ctx) => {
+  ctx.page({
+    path: '/llm-admin',
+    name: 'LLM 用户管理',
+    authority: 4,
+    order: 90,
+    component: Admin,
+  })
+}

--- a/plugins/llm-admin/client/index.js
+++ b/plugins/llm-admin/client/index.js
@@ -153,11 +153,20 @@ const Admin = defineComponent({
     const route = useRoute()
     const router = useRouter()
 
+    const SEARCH_PAGE = 50
+    const SESSION_PAGE = 30
+
     const q = ref('')
     const results = ref(null)
+    const searchTotal = ref(0)
+    const searchOffset = ref(0)
+    const searchingMore = ref(false)
     const searching = ref(false)
     const overview = ref(null)
     const sessions = ref(null)
+    const sessionTotal = ref(0)
+    const sessionOffset = ref(0)
+    const sessionsMore = ref(false)
     const msgs = ref(null)
     const err = ref('')
     const ready = ref(false)
@@ -167,13 +176,39 @@ const Admin = defineComponent({
 
     async function doSearch() {
       searching.value = true
+      searchOffset.value = 0
       err.value = ''
       try {
-        results.value = await send('llm-admin/search', { q: q.value })
+        const res = await send('llm-admin/search', {
+          q: q.value,
+          limit: SEARCH_PAGE,
+          offset: 0,
+        })
+        results.value = res.users
+        searchTotal.value = res.total
       } catch (e) {
         err.value = e?.message ?? String(e)
       } finally {
         searching.value = false
+      }
+    }
+    async function loadMoreSearch() {
+      searchingMore.value = true
+      err.value = ''
+      try {
+        const offset = searchOffset.value + SEARCH_PAGE
+        const res = await send('llm-admin/search', {
+          q: q.value,
+          limit: SEARCH_PAGE,
+          offset,
+        })
+        searchOffset.value = offset
+        results.value = [...(results.value || []), ...res.users]
+        searchTotal.value = res.total
+      } catch (e) {
+        err.value = e?.message ?? String(e)
+      } finally {
+        searchingMore.value = false
       }
     }
 
@@ -190,11 +225,40 @@ const Admin = defineComponent({
     async function loadUser(id) {
       overview.value = null
       sessions.value = null
+      sessionOffset.value = 0
+      sessionTotal.value = 0
       try {
         overview.value = await send('llm-admin/overview', { id })
-        sessions.value = await send('llm-admin/sessions', { id })
+        const res = await send('llm-admin/sessions', {
+          id,
+          limit: SESSION_PAGE,
+          offset: 0,
+        })
+        sessions.value = res.rows
+        sessionTotal.value = res.total
       } catch (e) {
         err.value = e?.message ?? String(e)
+      }
+    }
+    async function loadMoreSessions() {
+      const id = uid()
+      if (id == null) return
+      sessionsMore.value = true
+      err.value = ''
+      try {
+        const offset = sessionOffset.value + SESSION_PAGE
+        const res = await send('llm-admin/sessions', {
+          id,
+          limit: SESSION_PAGE,
+          offset,
+        })
+        sessionOffset.value = offset
+        sessions.value = [...(sessions.value || []), ...res.rows]
+        sessionTotal.value = res.total
+      } catch (e) {
+        err.value = e?.message ?? String(e)
+      } finally {
+        sessionsMore.value = false
       }
     }
     async function loadSession(conv) {
@@ -266,13 +330,24 @@ const Admin = defineComponent({
         results.value === null
           ? h('p', { class: 'la-dim' }, '输入后搜索，或留空点搜索列出全部聊过的用户。')
           : results.value.length
-            ? h(
-                'div',
-                { class: 'la-result-list' },
-                results.value.map((u) =>
+            ? h('div', { class: 'la-result-list' }, [
+                ...results.value.map((u) =>
                   h('div', { class: 'la-result', onClick: () => openUser(u.id) }, ident(u))
-                )
-              )
+                ),
+                results.value.length < searchTotal.value
+                  ? h(
+                      'button',
+                      {
+                        class: 'la-btn la-more',
+                        disabled: searchingMore.value,
+                        onClick: loadMoreSearch,
+                      },
+                      searchingMore.value
+                        ? '加载中…'
+                        : `加载更多（${results.value.length}/${searchTotal.value}）`
+                    )
+                  : null,
+              ])
             : h('p', { class: 'la-dim' }, '（无匹配用户）'),
       ])
     }
@@ -300,23 +375,38 @@ const Admin = defineComponent({
           sessions.value === null
             ? [h('p', { class: 'la-dim' }, '加载中…')]
             : sessions.value.length
-              ? sessions.value.map((s) =>
-                  h(
-                    'div',
-                    {
-                      class: ['la-session', cid() === s.conversationId ? 'active' : ''],
-                      onClick: () => openSession(s.conversationId),
-                    },
-                    [
-                      h('div', { class: 'la-session-title' }, [
-                        s.isCurrent ? h('span', { class: 'la-badge la-badge-cur' }, '当前') : null,
-                        s.isCompacted ? h('span', { class: 'la-badge' }, '压缩') : null,
-                        h('span', {}, s.title),
-                      ]),
-                      h('div', { class: 'la-session-meta' }, `${when(s.lastUsedAt)} · ${s.turns} 轮`),
-                    ]
-                  )
-                )
+              ? [
+                  ...sessions.value.map((s) =>
+                    h(
+                      'div',
+                      {
+                        class: ['la-session', cid() === s.conversationId ? 'active' : ''],
+                        onClick: () => openSession(s.conversationId),
+                      },
+                      [
+                        h('div', { class: 'la-session-title' }, [
+                          s.isCurrent ? h('span', { class: 'la-badge la-badge-cur' }, '当前') : null,
+                          s.isCompacted ? h('span', { class: 'la-badge' }, '压缩') : null,
+                          h('span', {}, s.title),
+                        ]),
+                        h('div', { class: 'la-session-meta' }, `${when(s.lastUsedAt)} · ${s.turns} 轮`),
+                      ]
+                    )
+                  ),
+                  sessions.value.length < sessionTotal.value
+                    ? h(
+                        'button',
+                        {
+                          class: 'la-btn la-more',
+                          disabled: sessionsMore.value,
+                          onClick: loadMoreSessions,
+                        },
+                        sessionsMore.value
+                          ? '加载中…'
+                          : `加载更多（${sessions.value.length}/${sessionTotal.value}）`
+                      )
+                    : null,
+                ]
               : [h('p', { class: 'la-dim' }, '（无会话）')]
         ),
       ])

--- a/plugins/llm-admin/client/index.js
+++ b/plugins/llm-admin/client/index.js
@@ -65,6 +65,137 @@ function trendSvg(trend) {
   return `<svg viewBox="0 0 ${W} ${H}" width="100%" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg"><polygon points="${t.join(' ')} ${base}" fill="var(--k-color-primary,#6a5acd)" fill-opacity="0.18"/><polygon points="${p.join(' ')} ${base}" fill="var(--k-color-primary,#6a5acd)" fill-opacity="0.35"/><polyline points="${t.join(' ')}" fill="none" stroke="var(--k-color-primary,#6a5acd)" stroke-width="1.5"/></svg>`
 }
 
+function utf8Len(s) {
+  return new TextEncoder().encode(s ?? '').length
+}
+
+// 长期记忆编辑卡片：进入总览时 memory-get 载入，实时字节计数对上限，
+// 超限标红并禁用保存；清空走 window.confirm 二次确认。隐私敏感。
+const MemoryCard = defineComponent({
+  name: 'LaMemoryCard',
+  props: { id: { type: Number, required: true } },
+  setup(props) {
+    const content = ref('')
+    const loaded = ref(false)
+    const saving = ref(false)
+    const clearing = ref(false)
+    const hardLimit = ref(3300)
+    const meta = ref(null)
+    const msg = ref('')
+
+    async function load() {
+      loaded.value = false
+      msg.value = ''
+      try {
+        const r = await send('llm-admin/memory-get', { id: props.id })
+        content.value = r.content ?? ''
+        hardLimit.value = r.hardLimit ?? 3300
+        meta.value = r
+      } catch (e) {
+        msg.value = e?.message ?? String(e)
+      } finally {
+        loaded.value = true
+      }
+    }
+    async function save() {
+      saving.value = true
+      msg.value = ''
+      try {
+        const r = await send('llm-admin/memory-save', {
+          id: props.id,
+          content: content.value,
+        })
+        if (r.ok) msg.value = `已保存（${r.byteSize} 字节）`
+        else msg.value = r.error || '保存失败'
+        if (r.ok) meta.value = { ...(meta.value || {}), byteSize: r.byteSize }
+      } catch (e) {
+        msg.value = e?.message ?? String(e)
+      } finally {
+        saving.value = false
+      }
+    }
+    async function clear() {
+      if (!window.confirm('确认清空该用户长期记忆？此操作不可撤销。')) return
+      clearing.value = true
+      msg.value = ''
+      try {
+        const r = await send('llm-admin/memory-clear', { id: props.id })
+        if (r.ok) {
+          content.value = ''
+          meta.value = null
+          msg.value = '已清空'
+        } else {
+          msg.value = '无记忆可清空'
+        }
+      } catch (e) {
+        msg.value = e?.message ?? String(e)
+      } finally {
+        clearing.value = false
+      }
+    }
+
+    onMounted(load)
+    watch(() => props.id, load)
+
+    return () => {
+      const KCard = resolveComponent('k-card')
+      const size = utf8Len(content.value)
+      const over = size > hardLimit.value
+      return h(KCard, { class: 'la-panel la-mem' }, {
+        default: () => [
+          h('div', { class: 'la-panel-title' }, '长期记忆 · 隐私敏感'),
+          !loaded.value
+            ? h('p', { class: 'la-dim' }, '加载中…')
+            : h('div', { class: 'la-mem-body' }, [
+                h('textarea', {
+                  class: ['la-mem-textarea', over ? 'over' : ''],
+                  value: content.value,
+                  spellcheck: 'false',
+                  placeholder: '（该用户暂无长期记忆，可在此写入）',
+                  onInput: (e) => (content.value = e.target.value),
+                }),
+                h('div', { class: 'la-mem-bar' }, [
+                  h(
+                    'span',
+                    { class: ['la-mem-count', over ? 'over' : ''] },
+                    `${size} / ${hardLimit.value} 字节`
+                  ),
+                  meta.value
+                    ? h(
+                        'span',
+                        { class: 'la-dim la-mem-updated' },
+                        `更新 ${meta.value.updateCount ?? 0} 次 · ${when(meta.value.lastUpdated)}`
+                      )
+                    : null,
+                ]),
+                h('div', { class: 'la-mem-actions' }, [
+                  h(
+                    'button',
+                    {
+                      class: 'la-btn',
+                      disabled: over || saving.value,
+                      onClick: save,
+                    },
+                    saving.value ? '保存中…' : '保存'
+                  ),
+                  h(
+                    'button',
+                    {
+                      class: 'la-btn la-mem-clear',
+                      disabled: clearing.value,
+                      onClick: clear,
+                    },
+                    clearing.value ? '清空中…' : '清空 ⚠'
+                  ),
+                  msg.value ? h('span', { class: 'la-mem-msg' }, msg.value) : null,
+                ]),
+              ]),
+        ],
+      })
+    }
+  },
+})
+
 function overviewView(o) {
   const KCard = resolveComponent('k-card')
   const cards = [
@@ -115,6 +246,7 @@ function overviewView(o) {
           : h('p', { class: 'la-dim' }, '（无数据）'),
       ],
     }),
+    h(MemoryCard, { id: o.id, key: o.id }),
   ])
 }
 

--- a/plugins/llm-admin/client/index.js
+++ b/plugins/llm-admin/client/index.js
@@ -1,4 +1,4 @@
-import { defineComponent, h, onMounted, ref, resolveComponent, watch } from '../vue.js'
+import { defineComponent, h, nextTick, onMounted, ref, resolveComponent, watch } from '../vue.js'
 import { useRoute, useRouter } from '../vue-router.js'
 import { send, store } from '../client.js'
 
@@ -141,10 +141,13 @@ function renderMsg(m) {
   ])
 }
 
-function chatView(msgs) {
+function chatView(msgs, scrollRef, onScroll, loadingMore) {
   if (msgs === null) return h('div', { class: 'la-dim la-chat-empty' }, '加载中…')
   if (!msgs.length) return h('div', { class: 'la-dim la-chat-empty' }, '（空会话）')
-  return h('div', { class: 'la-chat' }, msgs.map(renderMsg))
+  return h('div', { class: 'la-chat', ref: scrollRef, onScroll }, [
+    loadingMore ? h('div', { class: 'la-dim la-chat-more' }, '加载更早…') : null,
+    ...msgs.map(renderMsg),
+  ])
 }
 
 const Admin = defineComponent({
@@ -168,6 +171,11 @@ const Admin = defineComponent({
     const sessionOffset = ref(0)
     const sessionsMore = ref(false)
     const msgs = ref(null)
+    const MSG_PAGE = 20
+    const earliestTurn = ref(null)
+    const msgsHasMore = ref(false)
+    const loadingMoreMsgs = ref(false)
+    const chatEl = ref(null)
     const err = ref('')
     const ready = ref(false)
 
@@ -263,11 +271,53 @@ const Admin = defineComponent({
     }
     async function loadSession(conv) {
       msgs.value = null
+      earliestTurn.value = null
+      msgsHasMore.value = false
       try {
-        msgs.value = await send('llm-admin/session', { conversationId: conv })
+        const res = await send('llm-admin/session', {
+          conversationId: conv,
+          limit: MSG_PAGE,
+          beforeTurn: null,
+        })
+        msgs.value = res.messages
+        earliestTurn.value = res.earliestTurn
+        msgsHasMore.value = res.hasMore
+        // 渲染后定位到底部（聊天软件式：最新在下方）
+        await nextTick()
+        const el = chatEl.value
+        if (el) el.scrollTop = el.scrollHeight
       } catch (e) {
         err.value = e?.message ?? String(e)
       }
+    }
+    // 上滚加载更早：prepend 到头部并保持视觉位置不跳
+    async function loadMoreMsgs() {
+      const conv = cid()
+      if (conv == null || !msgsHasMore.value || loadingMoreMsgs.value) return
+      loadingMoreMsgs.value = true
+      err.value = ''
+      const el = chatEl.value
+      const prevHeight = el ? el.scrollHeight : 0
+      try {
+        const res = await send('llm-admin/session', {
+          conversationId: conv,
+          limit: MSG_PAGE,
+          beforeTurn: earliestTurn.value,
+        })
+        msgs.value = [...res.messages, ...(msgs.value || [])]
+        earliestTurn.value = res.earliestTurn ?? earliestTurn.value
+        msgsHasMore.value = res.hasMore
+        await nextTick()
+        if (el) el.scrollTop += el.scrollHeight - prevHeight
+      } catch (e) {
+        err.value = e?.message ?? String(e)
+      } finally {
+        loadingMoreMsgs.value = false
+      }
+    }
+    function onChatScroll(e) {
+      if (e.target.scrollTop < 60 && msgsHasMore.value && !loadingMoreMsgs.value)
+        loadMoreMsgs()
     }
 
     // 路由驱动的数据加载（真实 URL：?user=&session=）
@@ -413,7 +463,7 @@ const Admin = defineComponent({
       const right = h('div', { class: 'la-right' }, [
         err.value ? h('div', { class: 'la-err' }, err.value) : null,
         inSession
-          ? chatView(msgs.value)
+          ? chatView(msgs.value, chatEl, onChatScroll, loadingMoreMsgs.value)
           : o
             ? overviewView(o)
             : h('div', { class: 'la-dim' }, '加载中…'),

--- a/plugins/llm-admin/client/index.js
+++ b/plugins/llm-admin/client/index.js
@@ -310,6 +310,7 @@ const Admin = defineComponent({
     const chatEl = ref(null)
     const err = ref('')
     const ready = ref(false)
+    const rotating = ref(false)
 
     const uid = () => (route.query.user ? Number(route.query.user) : null)
     const cid = () => route.query.session || null
@@ -378,6 +379,28 @@ const Admin = defineComponent({
         sessionTotal.value = res.total
       } catch (e) {
         err.value = e?.message ?? String(e)
+      }
+    }
+    // 强制轮转：写操作，二次确认后 send，成功刷新会话列表（新会话应标「当前」）
+    async function rotate(e) {
+      e.stopPropagation() // 防冒泡触发头部「回总览」
+      const id = uid()
+      if (id == null || rotating.value) return
+      if (
+        !window.confirm(
+          '确认给该用户强制轮转 session？下条消息将从空白新会话开始。'
+        )
+      )
+        return
+      rotating.value = true
+      err.value = ''
+      try {
+        await send('llm-admin/rotate', { id })
+        await loadUser(id)
+      } catch (e2) {
+        err.value = e2?.message ?? String(e2)
+      } finally {
+        rotating.value = false
       }
     }
     async function loadMoreSessions() {
@@ -547,7 +570,18 @@ const Admin = defineComponent({
             onClick: backToOverview,
           },
           [
-            h('button', { class: 'la-back', onClick: (e) => { e.stopPropagation(); goSearch() } }, '← 返回搜索'),
+            h('div', { class: 'la-user-head-top' }, [
+              h('button', { class: 'la-back', onClick: (e) => { e.stopPropagation(); goSearch() } }, '← 返回搜索'),
+              h(
+                'button',
+                {
+                  class: 'la-btn la-rotate',
+                  disabled: rotating.value,
+                  onClick: rotate,
+                },
+                rotating.value ? '轮转中…' : '强制轮转 ⚠'
+              ),
+            ]),
             h('div', { class: 'la-user-ident' }, ident(headIdent)),
             h('div', { class: 'la-user-meta' }, o ? `${o.sessionCount} 个会话 · ${fmtShort(o.totalTokens)} tok` : '加载中…'),
             inSession ? h('div', { class: 'la-user-hint' }, '← 点此看用户总览') : null,

--- a/plugins/llm-admin/client/index.js
+++ b/plugins/llm-admin/client/index.js
@@ -1,4 +1,4 @@
-import { defineComponent, h, nextTick, onMounted, ref, resolveComponent, watch } from '../vue.js'
+import { defineComponent, h, nextTick, onMounted, onUnmounted, ref, resolveComponent, watch } from '../vue.js'
 import { useRoute, useRouter } from '../vue-router.js'
 import { send, store } from '../client.js'
 
@@ -250,6 +250,21 @@ function overviewView(o) {
   ])
 }
 
+// agent 消息的 token 消耗徽标：↑输入 ↓输出（有缓存则 ⚡缓存），hover 看精确值。
+// cachedTokens ⊂ promptTokens，仅展示不叠加。
+function msgTokens(u) {
+  if (!u) return null
+  const prompt = u.promptTokens ?? 0
+  const completion = u.completionTokens ?? 0
+  const cached = u.cachedTokens ?? 0
+  const total = u.totalTokens ?? prompt + completion
+  if (!total && !prompt && !completion) return null
+  const parts = [`↑${fmtShort(prompt)}`, `↓${fmtShort(completion)}`]
+  if (cached) parts.push(`⚡${fmtShort(cached)}`)
+  const title = `输入 ${fmt(prompt)} · 输出 ${fmt(completion)} · 缓存 ${fmt(cached)} · 合计 ${fmt(total)}`
+  return h('span', { class: 'la-msg-tokens', title }, parts.join(' '))
+}
+
 function renderMsg(m) {
   if (m.role === 'tool') {
     // 工具结果：吵，默认折叠
@@ -266,17 +281,24 @@ function renderMsg(m) {
   if (m.role === 'assistant' && m.toolCalls)
     kids.push(fold('la-tool', `🔧 调用 ${toolNames(m.toolCalls)}`, prettyJson(m.toolCalls)))
   const label = m.role === 'user' ? '用户' : m.role === 'assistant' ? 'SILI' : m.role
+  const meta = [h('span', { class: 'la-msg-time' }, when(m.time))]
+  if (m.role === 'assistant') {
+    const t = msgTokens(m.usage)
+    if (t) meta.push(t)
+  }
   return h('div', { class: `la-msg la-msg-${m.role}` }, [
     h('div', { class: 'la-msg-role' }, label),
     h('div', { class: 'la-bubble' }, kids),
-    h('div', { class: 'la-msg-time' }, when(m.time)),
+    h('div', { class: 'la-msg-meta' }, meta),
   ])
 }
 
-function chatView(msgs, scrollRef, onScroll, loadingMore) {
+function chatView(msgs, sentinelRef, loadingMore) {
   if (msgs === null) return h('div', { class: 'la-dim la-chat-empty' }, '加载中…')
   if (!msgs.length) return h('div', { class: 'la-dim la-chat-empty' }, '（空会话）')
-  return h('div', { class: 'la-chat', ref: scrollRef, onScroll }, [
+  // 顶部哨兵：滚动容器是 .la-right，IntersectionObserver 盯这个哨兵进视口触发上滚加载。
+  return h('div', { class: 'la-chat' }, [
+    h('div', { class: 'la-chat-top', ref: sentinelRef }),
     loadingMore ? h('div', { class: 'la-dim la-chat-more' }, '加载更早…') : null,
     ...msgs.map(renderMsg),
   ])
@@ -307,7 +329,9 @@ const Admin = defineComponent({
     const earliestTurn = ref(null)
     const msgsHasMore = ref(false)
     const loadingMoreMsgs = ref(false)
-    const chatEl = ref(null)
+    const chatEl = ref(null) // 滚动容器 = .la-right（滚动条贴面板最右缘）
+    const sentinelEl = ref(null) // .la-chat 顶部哨兵，供 IntersectionObserver 触发上滚加载
+    let msgObserver = null
     const err = ref('')
     const ready = ref(false)
     const rotating = ref(false)
@@ -437,10 +461,11 @@ const Admin = defineComponent({
         msgs.value = res.messages
         earliestTurn.value = res.earliestTurn
         msgsHasMore.value = res.hasMore
-        // 渲染后定位到底部（聊天软件式：最新在下方）
+        // 渲染后定位到底部（聊天软件式：最新在下方），再挂哨兵 observer
         await nextTick()
         const el = chatEl.value
         if (el) el.scrollTop = el.scrollHeight
+        setupMsgObserver()
       } catch (e) {
         err.value = e?.message ?? String(e)
       }
@@ -470,10 +495,28 @@ const Admin = defineComponent({
         loadingMoreMsgs.value = false
       }
     }
-    function onChatScroll(e) {
-      if (e.target.scrollTop < 60 && msgsHasMore.value && !loadingMoreMsgs.value)
-        loadMoreMsgs()
+    // 无限上滚：IntersectionObserver 盯顶部哨兵，进视口（root=.la-right，提前 80px）就加载更早。
+    // 比 scroll 监听更地道：无需猜阈值、无高频事件；防跳仍靠 loadMoreMsgs 里的 scrollHeight 补偿。
+    function setupMsgObserver() {
+      teardownMsgObserver()
+      const root = chatEl.value
+      const target = sentinelEl.value
+      if (!root || !target || typeof IntersectionObserver === 'undefined') return
+      msgObserver = new IntersectionObserver(
+        (entries) => {
+          if (entries.some((e) => e.isIntersecting)) loadMoreMsgs()
+        },
+        { root, rootMargin: '80px 0px 0px 0px', threshold: 0 }
+      )
+      msgObserver.observe(target)
     }
+    function teardownMsgObserver() {
+      if (msgObserver) {
+        msgObserver.disconnect()
+        msgObserver = null
+      }
+    }
+    onUnmounted(teardownMsgObserver)
 
     // 路由驱动的数据加载（真实 URL：?user=&session=）
     watch(
@@ -485,6 +528,8 @@ const Admin = defineComponent({
         if (u == null) {
           loadedUser = loadedConv = null
           overview.value = sessions.value = msgs.value = null
+          msgsHasMore.value = false
+          teardownMsgObserver()
           return
         }
         if (loadedUser !== u) {
@@ -499,6 +544,8 @@ const Admin = defineComponent({
         } else {
           loadedConv = null
           msgs.value = null
+          msgsHasMore.value = false
+          teardownMsgObserver()
         }
       },
       { immediate: true }
@@ -626,10 +673,10 @@ const Admin = defineComponent({
               : [h('p', { class: 'la-dim' }, '（无会话）')]
         ),
       ])
-      const right = h('div', { class: 'la-right' }, [
+      const right = h('div', { class: 'la-right', ref: chatEl }, [
         err.value ? h('div', { class: 'la-err' }, err.value) : null,
         inSession
-          ? chatView(msgs.value, chatEl, onChatScroll, loadingMoreMsgs.value)
+          ? chatView(msgs.value, sentinelEl, loadingMoreMsgs.value)
           : o
             ? overviewView(o)
             : h('div', { class: 'la-dim' }, '加载中…'),

--- a/plugins/llm-admin/client/style.css
+++ b/plugins/llm-admin/client/style.css
@@ -45,9 +45,22 @@
 .la-user-head.clickable { cursor: pointer; }
 .la-user-head.clickable:hover { background: var(--k-hover-bg, rgba(128,128,128,0.06)); }
 .la-user-hint { font-size: 0.72rem; color: var(--k-color-primary, #6a5acd); margin-top: 0.35rem; }
+.la-user-head-top {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 0.6rem; margin-bottom: 0.5rem;
+}
 .la-back {
   background: none; border: none; color: var(--k-color-primary, #6a5acd);
-  cursor: pointer; padding: 0; font-size: 0.85rem; margin-bottom: 0.5rem;
+  cursor: pointer; padding: 0; font-size: 0.85rem;
+}
+/* 强制轮转：写操作，警示色（danger 边框 + 文字，透明底） */
+.la-rotate {
+  padding: 0.3rem 0.7rem; font-size: 0.78rem;
+  background: none; color: var(--k-color-danger, #e0533d);
+  border: 1px solid var(--k-color-danger, #e0533d);
+}
+.la-rotate:hover:not(:disabled) {
+  background: var(--k-color-danger, #e0533d); color: #fff;
 }
 .la-user-ident { font-size: 1.05rem; margin-bottom: 0.25rem; }
 .la-user-meta { font-size: 0.8rem; color: var(--k-text-light, #999); }

--- a/plugins/llm-admin/client/style.css
+++ b/plugins/llm-admin/client/style.css
@@ -74,7 +74,7 @@
 }
 .la-badge-cur { background: var(--k-color-primary, #6a5acd); color: #fff; }
 
-.la-right { min-height: 0; overflow-y: auto; padding: 1.2rem; }
+.la-right { min-height: 0; overflow-y: auto; padding: 1.2rem; display: flex; flex-direction: column; }
 
 /* ---------- 总览 ---------- */
 .la-overview { display: flex; flex-direction: column; gap: 1rem; }
@@ -94,8 +94,13 @@
 .la-model-row { display: flex; justify-content: space-between; gap: 1rem; }
 
 /* ---------- chat 回放 ---------- */
-.la-chat { display: flex; flex-direction: column; gap: 0.8rem; max-width: 900px; margin: 0 auto; }
+.la-chat {
+  flex: 1; min-height: 0; overflow-y: auto;
+  display: flex; flex-direction: column; gap: 0.8rem;
+  width: 100%; max-width: 900px; margin: 0 auto;
+}
 .la-chat-empty { padding: 2rem; text-align: center; }
+.la-chat-more { text-align: center; font-size: 0.78rem; padding: 0.3rem 0; }
 .la-msg { display: flex; flex-direction: column; gap: 0.2rem; }
 .la-msg-role { font-size: 0.72rem; color: var(--k-text-light, #999); }
 .la-msg-time { font-size: 0.68rem; color: var(--k-text-light, #999); margin-top: 0.15rem; }

--- a/plugins/llm-admin/client/style.css
+++ b/plugins/llm-admin/client/style.css
@@ -1,0 +1,119 @@
+.la-root { height: 100%; box-sizing: border-box; display: flex; flex-direction: column; }
+.la-dim { color: var(--k-text-light, #999); }
+.la-err { color: var(--k-color-danger, #e0533d); margin: 0.5rem 0; }
+.la-notice {
+  font-size: 0.8rem; color: var(--k-text-light, #999);
+  background: var(--k-color-warning-fade, rgba(224,120,60,0.08));
+  border: 1px solid var(--k-color-border, #eee); border-radius: 6px;
+  padding: 0.4rem 0.7rem; margin-bottom: 1rem;
+}
+
+/* ---------- 搜索视图 ---------- */
+.la-search { padding: 1.5rem; overflow-y: auto; }
+.la-search-form { display: flex; gap: 0.6rem; margin-bottom: 1rem; }
+.la-input {
+  flex: 1; padding: 0.5rem 0.8rem; border-radius: 6px; font-size: 0.9rem;
+  border: 1px solid var(--k-color-border, #d0d0d0); background: var(--k-card-bg, #fff); color: inherit;
+}
+.la-btn {
+  padding: 0.5rem 1.1rem; border-radius: 6px; cursor: pointer; font-size: 0.9rem;
+  border: 1px solid transparent; background: var(--k-color-primary, #6a5acd); color: #fff;
+}
+.la-btn:disabled { opacity: 0.5; cursor: default; }
+.la-result-list { display: flex; flex-direction: column; gap: 0.3rem; }
+.la-result {
+  padding: 0.6rem 0.8rem; border-radius: 6px; cursor: pointer;
+  border: 1px solid var(--k-color-border, #eee); background: var(--k-card-bg, #fff);
+}
+.la-result:hover { border-color: var(--k-color-primary, #6a5acd); }
+
+/* 身份 */
+.la-nick { font-weight: 600; margin-right: 0.4rem; }
+.la-acct { color: var(--k-text-normal, #666); margin-right: 0.4rem; }
+.la-uid { color: var(--k-text-light, #999); font-size: 0.85em; }
+
+/* ---------- 详情：master-detail ---------- */
+.la-detail { flex: 1; min-height: 0; display: grid; grid-template-columns: 320px 1fr; }
+.la-left {
+  min-height: 0; display: flex; flex-direction: column;
+  border-right: 1px solid var(--k-color-border, #eee);
+}
+.la-user-head {
+  padding: 1rem; border-bottom: 1px solid var(--k-color-border, #eee);
+  position: sticky; top: 0; background: var(--k-page-bg, var(--k-card-bg, #fff)); z-index: 1;
+}
+.la-user-head.clickable { cursor: pointer; }
+.la-user-head.clickable:hover { background: var(--k-hover-bg, rgba(128,128,128,0.06)); }
+.la-user-hint { font-size: 0.72rem; color: var(--k-color-primary, #6a5acd); margin-top: 0.35rem; }
+.la-back {
+  background: none; border: none; color: var(--k-color-primary, #6a5acd);
+  cursor: pointer; padding: 0; font-size: 0.85rem; margin-bottom: 0.5rem;
+}
+.la-user-ident { font-size: 1.05rem; margin-bottom: 0.25rem; }
+.la-user-meta { font-size: 0.8rem; color: var(--k-text-light, #999); }
+
+.la-session-list { flex: 1; min-height: 0; overflow-y: auto; padding: 0.5rem; }
+.la-session {
+  padding: 0.55rem 0.7rem; border-radius: 6px; cursor: pointer; margin-bottom: 0.3rem;
+  border: 1px solid transparent;
+}
+.la-session:hover { background: var(--k-hover-bg, rgba(128,128,128,0.08)); }
+.la-session.active {
+  background: var(--k-hover-bg, rgba(106,90,205,0.12));
+  border-color: var(--k-color-primary, #6a5acd);
+}
+.la-session-title {
+  font-size: 0.88rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  margin-bottom: 0.2rem;
+}
+.la-session-meta { font-size: 0.72rem; color: var(--k-text-light, #999); }
+.la-badge {
+  display: inline-block; font-size: 0.65rem; padding: 0 0.35rem; border-radius: 4px;
+  background: var(--k-color-border, #ddd); color: var(--k-text-normal, #555); margin-right: 0.3rem;
+  vertical-align: middle;
+}
+.la-badge-cur { background: var(--k-color-primary, #6a5acd); color: #fff; }
+
+.la-right { min-height: 0; overflow-y: auto; padding: 1.2rem; }
+
+/* ---------- 总览 ---------- */
+.la-overview { display: flex; flex-direction: column; gap: 1rem; }
+.la-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 0.8rem; }
+.la-card {
+  background: var(--k-card-bg, #fff); border: 1px solid var(--k-color-border, #eee);
+  border-radius: 8px; padding: 0.8rem 1rem;
+}
+.la-card-label { font-size: 0.8rem; color: var(--k-text-light, #888); }
+.la-card-value { font-size: 1.4rem; font-weight: 600; margin: 0.2rem 0; }
+.la-card-sub { font-size: 0.72rem; color: var(--k-text-light, #888); }
+.la-panel-title { font-weight: 600; font-size: 0.9rem; margin-bottom: 0.6rem; }
+.la-chart { width: 100%; line-height: 0; }
+.la-chart svg { display: block; width: 100%; height: 150px; }
+.la-chart-axis { display: flex; justify-content: space-between; margin-top: 0.25rem; font-size: 0.72rem; color: var(--k-text-light, #999); }
+.la-models { display: flex; flex-direction: column; gap: 0.3rem; font-size: 0.85rem; }
+.la-model-row { display: flex; justify-content: space-between; gap: 1rem; }
+
+/* ---------- chat 回放 ---------- */
+.la-chat { display: flex; flex-direction: column; gap: 0.8rem; max-width: 900px; margin: 0 auto; }
+.la-chat-empty { padding: 2rem; text-align: center; }
+.la-msg { display: flex; flex-direction: column; gap: 0.2rem; }
+.la-msg-role { font-size: 0.72rem; color: var(--k-text-light, #999); }
+.la-msg-time { font-size: 0.68rem; color: var(--k-text-light, #999); margin-top: 0.15rem; }
+.la-bubble {
+  padding: 0.6rem 0.85rem; border-radius: 10px; font-size: 0.9rem; line-height: 1.5;
+  border: 1px solid var(--k-color-border, #eee); background: var(--k-card-bg, #fff);
+  max-width: 85%; word-break: break-word; white-space: pre-wrap;
+}
+.la-msg-user { align-items: flex-end; }
+.la-msg-user .la-bubble { background: var(--k-color-primary-fade, rgba(106,90,205,0.12)); }
+/* 工具结果不占大气泡，紧凑折叠、左对齐、弱化 */
+.la-msg-tool { margin: -0.2rem 0; }
+.la-msg-tool .la-fold { margin: 0; }
+.la-msg-text { white-space: pre-wrap; }
+.la-fold { margin: 0.3rem 0; }
+.la-fold summary { cursor: pointer; font-size: 0.78rem; color: var(--k-text-light, #999); user-select: none; }
+.la-fold pre {
+  margin: 0.4rem 0 0; padding: 0.5rem; border-radius: 6px; overflow-x: auto;
+  background: var(--k-hover-bg, rgba(128,128,128,0.08)); font-size: 0.78rem; white-space: pre-wrap; word-break: break-word;
+}
+.la-reasoning pre { color: var(--k-text-light, #888); font-style: italic; }

--- a/plugins/llm-admin/client/style.css
+++ b/plugins/llm-admin/client/style.css
@@ -107,16 +107,22 @@
 .la-model-row { display: flex; justify-content: space-between; gap: 1rem; }
 
 /* ---------- chat 回放 ---------- */
+/* 滚动容器是 .la-right（滚动条贴面板最右缘）；.la-chat 只负责居中排版，不自带滚动 */
 .la-chat {
-  flex: 1; min-height: 0; overflow-y: auto;
   display: flex; flex-direction: column; gap: 0.8rem;
   width: 100%; max-width: 900px; margin: 0 auto;
 }
+.la-chat-top { height: 1px; flex: none; } /* 顶部哨兵，IntersectionObserver 目标 */
 .la-chat-empty { padding: 2rem; text-align: center; }
 .la-chat-more { text-align: center; font-size: 0.78rem; padding: 0.3rem 0; }
 .la-msg { display: flex; flex-direction: column; gap: 0.2rem; }
 .la-msg-role { font-size: 0.72rem; color: var(--k-text-light, #999); }
-.la-msg-time { font-size: 0.68rem; color: var(--k-text-light, #999); margin-top: 0.15rem; }
+.la-msg-meta { display: flex; gap: 0.5rem; align-items: baseline; margin-top: 0.15rem; flex-wrap: wrap; }
+.la-msg-time { font-size: 0.68rem; color: var(--k-text-light, #999); }
+.la-msg-tokens {
+  font-size: 0.68rem; color: var(--k-text-light, #999);
+  font-variant-numeric: tabular-nums; letter-spacing: 0.02em;
+}
 .la-bubble {
   padding: 0.6rem 0.85rem; border-radius: 10px; font-size: 0.9rem; line-height: 1.5;
   border: 1px solid var(--k-color-border, #eee); background: var(--k-card-bg, #fff);

--- a/plugins/llm-admin/client/style.css
+++ b/plugins/llm-admin/client/style.css
@@ -122,3 +122,24 @@
   background: var(--k-hover-bg, rgba(128,128,128,0.08)); font-size: 0.78rem; white-space: pre-wrap; word-break: break-word;
 }
 .la-reasoning pre { color: var(--k-text-light, #888); font-style: italic; }
+
+/* ---------- 长期记忆编辑卡片（隐私敏感） ---------- */
+.la-mem-body { display: flex; flex-direction: column; gap: 0.6rem; }
+.la-mem-textarea {
+  width: 100%; box-sizing: border-box; min-height: 160px; resize: vertical;
+  padding: 0.6rem 0.7rem; border-radius: 6px; font-size: 0.85rem; line-height: 1.5;
+  font-family: var(--k-font-mono, ui-monospace, monospace);
+  border: 1px solid var(--k-color-border, #d0d0d0);
+  background: var(--k-card-bg, #fff); color: inherit;
+}
+.la-mem-textarea.over { border-color: var(--k-color-danger, #e0533d); }
+.la-mem-bar { display: flex; justify-content: space-between; align-items: baseline; font-size: 0.78rem; }
+.la-mem-count { color: var(--k-text-light, #999); }
+.la-mem-count.over { color: var(--k-color-danger, #e0533d); font-weight: 600; }
+.la-mem-updated { font-size: 0.75rem; }
+.la-mem-actions { display: flex; align-items: center; gap: 0.6rem; }
+.la-mem-clear {
+  background: none; color: var(--k-color-danger, #e0533d);
+  border: 1px solid var(--k-color-danger, #e0533d);
+}
+.la-mem-msg { font-size: 0.8rem; color: var(--k-text-light, #999); }

--- a/plugins/llm-admin/filters.ts
+++ b/plugins/llm-admin/filters.ts
@@ -1,0 +1,19 @@
+export function matchUser(
+  u: { id: number; name: string; account: string },
+  query: string
+): boolean {
+  const q = (query ?? '').trim().toLowerCase()
+  if (!q) return true
+  return (
+    `#${u.id}` === q ||
+    String(u.id) === q ||
+    u.account.toLowerCase().includes(q) ||
+    u.name.toLowerCase().includes(q)
+  )
+}
+
+export function paginate<T>(arr: T[], limit: number, offset: number): { total: number; page: T[] } {
+  const off = Math.max(0, offset | 0)
+  const lim = Math.max(0, limit | 0)
+  return { total: arr.length, page: arr.slice(off, off + lim) }
+}

--- a/plugins/llm-admin/filters.ts
+++ b/plugins/llm-admin/filters.ts
@@ -12,7 +12,11 @@ export function matchUser(
   )
 }
 
-export function paginate<T>(arr: T[], limit: number, offset: number): { total: number; page: T[] } {
+export function paginate<T>(
+  arr: T[],
+  limit: number,
+  offset: number
+): { total: number; page: T[] } {
   const off = Math.max(0, offset | 0)
   const lim = Math.max(0, limit | 0)
   return { total: arr.length, page: arr.slice(off, off + lim) }

--- a/plugins/llm-admin/index.ts
+++ b/plugins/llm-admin/index.ts
@@ -6,6 +6,7 @@ import '@koishijs/console'
 
 import { type UserOverview, type UserUsageRow, aggregateUserOverview } from './aggregate-user'
 import { matchUser, paginate } from './filters'
+import { turnWindow } from './turns'
 
 // ⚠ 隐私敏感：本插件暴露用户长期记忆与会话正文，authority 4（仅 sysop）门控所有
 // listener（读也拦），且服务端日志不落记忆/会话正文。这是原型 spike，正式版走 spec。
@@ -55,7 +56,11 @@ declare module '@koishijs/console' {
       limit?: number
       offset?: number
     }): { total: number; rows: SessionRow[] }
-    'llm-admin/session'(payload: { conversationId: string }): ChatMsg[]
+    'llm-admin/session'(payload: {
+      conversationId: string
+      limit?: number
+      beforeTurn?: number | null
+    }): { messages: ChatMsg[]; earliestTurn: number | null; hasMore: boolean }
   }
 }
 
@@ -185,13 +190,30 @@ export function apply(ctx: Context) {
     { authority: AUTH }
   )
 
-  // ---- 会话消息：chat 式回放 ----
+  // ---- 会话消息：chat 式回放（按 turn 窗口分页，前端无限上滚）----
   ctx.console.addListener(
     'llm-admin/session',
-    async ({ conversationId }) => {
-      const rows = (await db.get(
+    async ({ conversationId, limit = 20, beforeTurn = null }) => {
+      // 该会话所有 turn_number（升序去重）
+      const allRows = await db.get(
         'openai_chat',
         { conversation_id: conversationId },
+        { fields: ['turn_number'] }
+      )
+      const turns = [...new Set(allRows.map((r) => r.turn_number))].sort(
+        (a, b) => a - b
+      )
+      const { fromTurn, hasMore } = turnWindow(turns, limit, beforeTurn)
+      if (fromTurn == null)
+        return { messages: [], earliestTurn: null, hasMore: false }
+
+      const upper = beforeTurn == null ? Number.MAX_SAFE_INTEGER : beforeTurn
+      const rows = (await db.get(
+        'openai_chat',
+        {
+          conversation_id: conversationId,
+          turn_number: { $gte: fromTurn, $lt: upper },
+        },
         {
           fields: [
             'role',
@@ -218,7 +240,7 @@ export function apply(ctx: Context) {
         return (m ? m[1] : c).trim()
       }
 
-      return rows.map((r): ChatMsg => {
+      const messages = rows.map((r): ChatMsg => {
         if (r.role === 'user')
           return {
             time: r.time,
@@ -243,6 +265,7 @@ export function apply(ctx: Context) {
           toolCalls: r.tool_calls || undefined,
         }
       })
+      return { messages, earliestTurn: fromTurn, hasMore }
     },
     { authority: AUTH }
   )

--- a/plugins/llm-admin/index.ts
+++ b/plugins/llm-admin/index.ts
@@ -5,6 +5,7 @@ import { resolve } from 'node:path'
 import '@koishijs/console'
 
 import {
+  type Usage,
   type UserOverview,
   type UserUsageRow,
   aggregateUserOverview,
@@ -44,6 +45,7 @@ type ChatMsg = { time: number } & (
       content: string
       reasoning?: string
       toolCalls?: string
+      usage?: Usage | null // 该次 agent 调用的 token 消耗，供逐条展示
     }
   | { role: 'tool'; toolName?: string; content: string }
 )
@@ -256,6 +258,7 @@ export function apply(ctx: Context) {
             'tool_calls',
             'tool_name',
             'time',
+            'usage',
           ],
           sort: { turn_number: 'asc', intra_turn_seq: 'asc', id: 'asc' },
         } as any
@@ -266,6 +269,7 @@ export function apply(ctx: Context) {
         tool_calls: string
         tool_name: string
         time: number
+        usage: Usage | null
       }>
 
       // user 行存的是包装 envelope，抽取 <user_message> 内层供展示
@@ -297,6 +301,7 @@ export function apply(ctx: Context) {
           content: r.content,
           reasoning: r.reasoning_content || undefined,
           toolCalls: r.tool_calls || undefined,
+          usage: r.usage ?? null,
         }
       })
       return { messages, earliestTurn: fromTurn, hasMore }

--- a/plugins/llm-admin/index.ts
+++ b/plugins/llm-admin/index.ts
@@ -4,11 +4,12 @@ import { resolve } from 'node:path'
 
 import '@koishijs/console'
 
+import { type UserOverview, type UserUsageRow, aggregateUserOverview } from './aggregate-user'
+
 // ⚠ 隐私敏感：本插件暴露用户长期记忆与会话正文，authority 4（仅 sysop）门控所有
 // listener（读也拦），且服务端日志不落记忆/会话正文。这是原型 spike，正式版走 spec。
 
 const AUTH = 4
-const DAY = 86_400_000
 
 export const name = 'llm-admin'
 export const inject = ['console', 'database', 'llm']
@@ -18,18 +19,6 @@ interface AdminUser {
   id: number
   name: string
   account: string
-}
-interface UserOverview extends AdminUser {
-  sessionCount: number
-  firstActive: number | null
-  lastActive: number | null
-  calls: number
-  totalTokens: number
-  promptTokens: number
-  completionTokens: number
-  cachedTokens: number
-  models: Array<{ model: string; calls: number; totalTokens: number }>
-  trend: Array<{ date: string; promptTokens: number; completionTokens: number }>
 }
 interface SessionRow {
   conversationId: string
@@ -59,32 +48,6 @@ declare module '@koishijs/console' {
     'llm-admin/sessions'(payload: { id: number }): SessionRow[]
     'llm-admin/session'(payload: { conversationId: string }): ChatMsg[]
   }
-}
-
-interface Usage {
-  promptTokens?: number
-  completionTokens?: number
-  totalTokens?: number
-  cachedTokens?: number
-}
-// cachedTokens ⊂ promptTokens — 展示用，不计入 total。
-function tok(u: Usage | null) {
-  const prompt = u?.promptTokens ?? 0
-  const completion = u?.completionTokens ?? 0
-  const cached = u?.cachedTokens ?? 0
-  return {
-    prompt,
-    completion,
-    cached,
-    total: u?.totalTokens ?? prompt + completion,
-  }
-}
-
-function localDate(time: number): string {
-  const d = new Date(time)
-  const m = String(d.getMonth() + 1).padStart(2, '0')
-  const day = String(d.getDate()).padStart(2, '0')
-  return `${d.getFullYear()}-${m}-${day}`
 }
 
 export function apply(ctx: Context) {
@@ -149,83 +112,15 @@ export function apply(ctx: Context) {
         'openai_chat',
         { conversation_owner: id, role: 'assistant' },
         { fields: ['time', 'model', 'usage'] }
-      )) as unknown as Array<{
-        time: number
-        model: string
-        usage: Usage | null
-      }>
+      )) as unknown as UserUsageRow[]
       const sessionsOfUser = await db.get(
         'openai_session',
         { conversation_owner: id },
         { fields: ['id'] }
       )
 
-      let totalTokens = 0
-      let promptTokens = 0
-      let completionTokens = 0
-      let cachedTokens = 0
-      let firstActive: number | null = null
-      let lastActive: number | null = null
-      const byModel = new Map<string, { calls: number; totalTokens: number }>()
-      const now = Date.now()
-      const since = now - 30 * DAY
-      const byDay = new Map<
-        string,
-        { promptTokens: number; completionTokens: number }
-      >()
-
-      for (const r of rows) {
-        const t = tok(r.usage)
-        totalTokens += t.total
-        promptTokens += t.prompt
-        completionTokens += t.completion
-        cachedTokens += t.cached
-        if (firstActive === null || r.time < firstActive) firstActive = r.time
-        if (lastActive === null || r.time > lastActive) lastActive = r.time
-        const m = byModel.get(r.model) ?? { calls: 0, totalTokens: 0 }
-        m.calls += 1
-        m.totalTokens += t.total
-        byModel.set(r.model, m)
-        if (r.time >= since) {
-          const key = localDate(r.time)
-          const b = byDay.get(key) ?? { promptTokens: 0, completionTokens: 0 }
-          b.promptTokens += t.prompt
-          b.completionTokens += t.completion
-          byDay.set(key, b)
-        }
-      }
-
-      const trend: UserOverview['trend'] = []
-      for (
-        let d = new Date(since);
-        d.getTime() <= now;
-        d.setDate(d.getDate() + 1)
-      ) {
-        const key = localDate(d.getTime())
-        trend.push({
-          date: key,
-          ...(byDay.get(key) ?? { promptTokens: 0, completionTokens: 0 }),
-        })
-      }
-
-      const overview: UserOverview = {
-        id,
-        name: nameMap.get(id) || '',
-        account: acctMap.get(id) || '',
-        sessionCount: sessionsOfUser.length,
-        firstActive,
-        lastActive,
-        calls: rows.length,
-        totalTokens,
-        promptTokens,
-        completionTokens,
-        cachedTokens,
-        models: [...byModel.entries()]
-          .map(([model, v]) => ({ model, ...v }))
-          .sort((a, b) => b.totalTokens - a.totalTokens),
-        trend,
-      }
-      return overview
+      const identity = { id, name: nameMap.get(id) || '', account: acctMap.get(id) || '' }
+      return aggregateUserOverview(rows, sessionsOfUser.length, identity, Date.now())
     },
     { authority: AUTH }
   )

--- a/plugins/llm-admin/index.ts
+++ b/plugins/llm-admin/index.ts
@@ -353,6 +353,17 @@ export function apply(ctx: Context) {
       if (!check.ok) return check
       const existing = await memoryRow(id)
       const platform = existing?.platform ?? (await memoryPlatform(id))
+      // Orphan guard: with no binding and no existing memory row, platform
+      // falls back to 'unknown'. The llm runtime resolves a real platform (e.g.
+      // 'qq') for live sessions, so an 'unknown' row would never be read back —
+      // a silent orphan write. Reject with a diagnosable reason instead.
+      if (platform === 'unknown')
+        return {
+          ok: false,
+          byteSize: utf8ByteLength(content),
+          error:
+            '无法解析该用户的平台（无 binding 且无现有记忆行），写入将成为不会被读取的孤儿记忆行，已拒绝保存',
+        }
       // 保留 fork 节流元数据，避免打乱后台记忆调度
       await ctx.llm.memory.set(
         platform,
@@ -369,6 +380,9 @@ export function apply(ctx: Context) {
   ctx.console.addListener(
     'llm-admin/memory-clear',
     async ({ id }) => {
+      // memoryPlatform is existing-first internally (queries memoryRow before
+      // falling back to bindings), so this matches memory-save's platform
+      // resolution — no need to re-express the `existing?.platform ?? ...` form.
       const platform = await memoryPlatform(id)
       const ok = await ctx.llm.memory.delete(platform, String(id))
       return { ok }

--- a/plugins/llm-admin/index.ts
+++ b/plugins/llm-admin/index.ts
@@ -77,6 +77,11 @@ declare module '@koishijs/console' {
       error?: string
     }
     'llm-admin/memory-clear'(payload: { id: number }): { ok: boolean }
+    // 写操作：强制轮转 session（纯新开，不压缩、不带 prev_session_id）。
+    'llm-admin/rotate'(payload: { id: number }): {
+      ok: true
+      conversationId: string
+    }
   }
 }
 
@@ -354,6 +359,41 @@ export function apply(ctx: Context) {
       const platform = await memoryPlatform(id)
       const ok = await ctx.llm.memory.delete(platform, String(id))
       return { ok }
+    },
+    { authority: AUTH }
+  )
+
+  // ---- 强制轮转 session（写操作，仅 sysop）----
+  // 纯新开：mint 一个新 conversation_id，建全新 openai_session（不传
+  // prevSessionId → prev_session_id 落空串，非压缩派生），把 user 的
+  // openai_last_conversation_id 指向它，并同步在飞的 activeChats entry
+  // （若该用户此刻正有 chat 在跑），避免打断进来读到旧 id 又分歧。
+  // 复刻 commands/chat.tsx 的 idle-rotate 路径，但主动触发、且不做 summary。
+  // 日志只记 id / 新旧 conversation_id，绝不落会话正文。
+  ctx.console.addListener(
+    'llm-admin/rotate',
+    async ({ id }) => {
+      const newId = crypto.randomUUID()
+      const platform = await memoryPlatform(id)
+      await ctx.llm.sessions.create({
+        conversationId: newId,
+        conversationOwner: id,
+        platform,
+        userId: String(id),
+        userFirstMsg: '', // fresh blank session; no seeded utterance
+      })
+      await db.set('user', { id }, {
+        openai_last_conversation_id: newId,
+      } as any)
+      // activeChats 按 owner id 键；有在飞 chat 则把它写向新会话
+      const active = ctx.llm.activeChats.get(id)
+      if (active) active.conversationId = newId
+      ctx.logger('llm-admin').info(
+        '[rotate] user #%d rotated to fresh session %s',
+        id,
+        newId
+      )
+      return { ok: true, conversationId: newId }
     },
     { authority: AUTH }
   )

--- a/plugins/llm-admin/index.ts
+++ b/plugins/llm-admin/index.ts
@@ -1,0 +1,347 @@
+import { Context } from 'koishi'
+
+import { resolve } from 'node:path'
+
+import '@koishijs/console'
+
+// ⚠ 隐私敏感：本插件暴露用户长期记忆与会话正文，authority 4（仅 sysop）门控所有
+// listener（读也拦），且服务端日志不落记忆/会话正文。这是原型 spike，正式版走 spec。
+
+const AUTH = 4
+const DAY = 86_400_000
+
+export const name = 'llm-admin'
+export const inject = ['console', 'database', 'llm']
+
+// ---- 类型（供前端参考） ----
+interface AdminUser {
+  id: number
+  name: string
+  account: string
+}
+interface UserOverview extends AdminUser {
+  sessionCount: number
+  firstActive: number | null
+  lastActive: number | null
+  calls: number
+  totalTokens: number
+  promptTokens: number
+  completionTokens: number
+  cachedTokens: number
+  models: Array<{ model: string; calls: number; totalTokens: number }>
+  trend: Array<{ date: string; promptTokens: number; completionTokens: number }>
+}
+interface SessionRow {
+  conversationId: string
+  title: string
+  startedAt: number
+  lastUsedAt: number
+  isCurrent: boolean
+  isCompacted: boolean
+  turns: number
+}
+type ChatMsg = { time: number } & (
+  | { role: 'user'; content: string; raw?: string }
+  | { role: 'system'; content: string }
+  | {
+      role: 'assistant'
+      content: string
+      reasoning?: string
+      toolCalls?: string
+    }
+  | { role: 'tool'; toolName?: string; content: string }
+)
+
+declare module '@koishijs/console' {
+  interface Events {
+    'llm-admin/search'(payload: { q: string }): AdminUser[]
+    'llm-admin/overview'(payload: { id: number }): UserOverview | null
+    'llm-admin/sessions'(payload: { id: number }): SessionRow[]
+    'llm-admin/session'(payload: { conversationId: string }): ChatMsg[]
+  }
+}
+
+interface Usage {
+  promptTokens?: number
+  completionTokens?: number
+  totalTokens?: number
+  cachedTokens?: number
+}
+// cachedTokens ⊂ promptTokens — 展示用，不计入 total。
+function tok(u: Usage | null) {
+  const prompt = u?.promptTokens ?? 0
+  const completion = u?.completionTokens ?? 0
+  const cached = u?.cachedTokens ?? 0
+  return {
+    prompt,
+    completion,
+    cached,
+    total: u?.totalTokens ?? prompt + completion,
+  }
+}
+
+function localDate(time: number): string {
+  const d = new Date(time)
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${d.getFullYear()}-${m}-${day}`
+}
+
+export function apply(ctx: Context) {
+  const db = ctx.database
+
+  // 身份解析（复刻仪表盘：user.name + 首个 binding platform:pid）
+  async function resolveIdentities(ids: number[]) {
+    const nameMap = new Map<number, string>()
+    const acctMap = new Map<number, string>()
+    if (!ids.length) return { nameMap, acctMap }
+    const users = await db.get('user', { id: ids }, { fields: ['id', 'name'] })
+    for (const u of users) nameMap.set(u.id, u.name)
+    const bindings = await db.get(
+      'binding',
+      { aid: ids },
+      { fields: ['aid', 'platform', 'pid', 'bid'] }
+    )
+    for (const b of [...bindings].sort((a, b) => a.bid - b.bid)) {
+      if (!acctMap.has(b.aid)) acctMap.set(b.aid, `${b.platform}:${b.pid}`)
+    }
+    return { nameMap, acctMap }
+  }
+
+  // ---- 搜索：#id 精确 / platform:pid 子串 / 昵称子串 ----
+  ctx.console.addListener(
+    'llm-admin/search',
+    async ({ q }) => {
+      const query = (q ?? '').trim().toLowerCase()
+      // 候选池 = 有过会话的用户
+      const sessions = await db.get(
+        'openai_session',
+        {},
+        { fields: ['conversation_owner'] }
+      )
+      const ids = [...new Set(sessions.map((s) => s.conversation_owner))]
+      const { nameMap, acctMap } = await resolveIdentities(ids)
+      const all: AdminUser[] = ids.map((id) => ({
+        id,
+        name: nameMap.get(id) || '',
+        account: acctMap.get(id) || '',
+      }))
+      const matched = !query
+        ? all
+        : all.filter(
+            (u) =>
+              `#${u.id}` === query ||
+              String(u.id) === query ||
+              u.account.toLowerCase().includes(query) ||
+              u.name.toLowerCase().includes(query)
+          )
+      return matched.sort((a, b) => a.id - b.id).slice(0, 50)
+    },
+    { authority: AUTH }
+  )
+
+  // ---- 用户总览：使用量卡片 + 近30天趋势 + 模型分布 ----
+  ctx.console.addListener(
+    'llm-admin/overview',
+    async ({ id }) => {
+      const { nameMap, acctMap } = await resolveIdentities([id])
+      const rows = (await db.get(
+        'openai_chat',
+        { conversation_owner: id, role: 'assistant' },
+        { fields: ['time', 'model', 'usage'] }
+      )) as unknown as Array<{
+        time: number
+        model: string
+        usage: Usage | null
+      }>
+      const sessionsOfUser = await db.get(
+        'openai_session',
+        { conversation_owner: id },
+        { fields: ['id'] }
+      )
+
+      let totalTokens = 0
+      let promptTokens = 0
+      let completionTokens = 0
+      let cachedTokens = 0
+      let firstActive: number | null = null
+      let lastActive: number | null = null
+      const byModel = new Map<string, { calls: number; totalTokens: number }>()
+      const now = Date.now()
+      const since = now - 30 * DAY
+      const byDay = new Map<
+        string,
+        { promptTokens: number; completionTokens: number }
+      >()
+
+      for (const r of rows) {
+        const t = tok(r.usage)
+        totalTokens += t.total
+        promptTokens += t.prompt
+        completionTokens += t.completion
+        cachedTokens += t.cached
+        if (firstActive === null || r.time < firstActive) firstActive = r.time
+        if (lastActive === null || r.time > lastActive) lastActive = r.time
+        const m = byModel.get(r.model) ?? { calls: 0, totalTokens: 0 }
+        m.calls += 1
+        m.totalTokens += t.total
+        byModel.set(r.model, m)
+        if (r.time >= since) {
+          const key = localDate(r.time)
+          const b = byDay.get(key) ?? { promptTokens: 0, completionTokens: 0 }
+          b.promptTokens += t.prompt
+          b.completionTokens += t.completion
+          byDay.set(key, b)
+        }
+      }
+
+      const trend: UserOverview['trend'] = []
+      for (
+        let d = new Date(since);
+        d.getTime() <= now;
+        d.setDate(d.getDate() + 1)
+      ) {
+        const key = localDate(d.getTime())
+        trend.push({
+          date: key,
+          ...(byDay.get(key) ?? { promptTokens: 0, completionTokens: 0 }),
+        })
+      }
+
+      const overview: UserOverview = {
+        id,
+        name: nameMap.get(id) || '',
+        account: acctMap.get(id) || '',
+        sessionCount: sessionsOfUser.length,
+        firstActive,
+        lastActive,
+        calls: rows.length,
+        totalTokens,
+        promptTokens,
+        completionTokens,
+        cachedTokens,
+        models: [...byModel.entries()]
+          .map(([model, v]) => ({ model, ...v }))
+          .sort((a, b) => b.totalTokens - a.totalTokens),
+        trend,
+      }
+      return overview
+    },
+    { authority: AUTH }
+  )
+
+  // ---- 会话列表：按最后活跃倒序 ----
+  ctx.console.addListener(
+    'llm-admin/sessions',
+    async ({ id }) => {
+      const rows = await db.get(
+        'openai_session',
+        { conversation_owner: id },
+        {
+          fields: [
+            'conversation_id',
+            'user_first_msg',
+            'started_at',
+            'last_used_at',
+            'prev_session_id',
+          ],
+        }
+      )
+      const user = await db.get(
+        'user',
+        { id },
+        { fields: ['openai_last_conversation_id'] }
+      )
+      const currentConv = (user[0] as any)?.openai_last_conversation_id ?? ''
+      // 每会话轮数（去重 turn_number）
+      const result: SessionRow[] = []
+      for (const s of rows) {
+        const chatRows = await db.get(
+          'openai_chat',
+          { conversation_id: s.conversation_id },
+          { fields: ['turn_number'] }
+        )
+        const turns = new Set(chatRows.map((c) => c.turn_number)).size
+        result.push({
+          conversationId: s.conversation_id,
+          title: s.user_first_msg || '(空)',
+          startedAt: s.started_at,
+          lastUsedAt: s.last_used_at,
+          isCurrent: s.conversation_id === currentConv,
+          isCompacted: !!s.prev_session_id,
+          turns,
+        })
+      }
+      return result.sort((a, b) => b.lastUsedAt - a.lastUsedAt)
+    },
+    { authority: AUTH }
+  )
+
+  // ---- 会话消息：chat 式回放 ----
+  ctx.console.addListener(
+    'llm-admin/session',
+    async ({ conversationId }) => {
+      const rows = (await db.get(
+        'openai_chat',
+        { conversation_id: conversationId },
+        {
+          fields: [
+            'role',
+            'content',
+            'reasoning_content',
+            'tool_calls',
+            'tool_name',
+            'time',
+          ],
+          sort: { turn_number: 'asc', intra_turn_seq: 'asc', id: 'asc' },
+        } as any
+      )) as unknown as Array<{
+        role: string
+        content: string
+        reasoning_content: string
+        tool_calls: string
+        tool_name: string
+        time: number
+      }>
+
+      // user 行存的是包装 envelope，抽取 <user_message> 内层供展示
+      const extractUser = (c: string) => {
+        const m = c.match(/<user_message>([\s\S]*?)<\/user_message>/)
+        return (m ? m[1] : c).trim()
+      }
+
+      return rows.map((r): ChatMsg => {
+        if (r.role === 'user')
+          return {
+            time: r.time,
+            role: 'user',
+            content: extractUser(r.content),
+            raw: r.content, // 完整 envelope（<turn_context> + <user_message>）供折叠查看
+          }
+        if (r.role === 'system')
+          return { time: r.time, role: 'system', content: r.content }
+        if (r.role === 'tool')
+          return {
+            time: r.time,
+            role: 'tool',
+            toolName: r.tool_name,
+            content: r.content,
+          }
+        return {
+          time: r.time,
+          role: 'assistant',
+          content: r.content,
+          reasoning: r.reasoning_content || undefined,
+          toolCalls: r.tool_calls || undefined,
+        }
+      })
+    },
+    { authority: AUTH }
+  )
+
+  const clientDir = resolve(
+    ctx.baseDir,
+    'node_modules/koishi-plugin-llm-admin/client'
+  )
+  ctx.console.addEntry({ dev: clientDir, prod: clientDir })
+}

--- a/plugins/llm-admin/index.ts
+++ b/plugins/llm-admin/index.ts
@@ -5,6 +5,7 @@ import { resolve } from 'node:path'
 import '@koishijs/console'
 
 import { type UserOverview, type UserUsageRow, aggregateUserOverview } from './aggregate-user'
+import { matchUser, paginate } from './filters'
 
 // ⚠ 隐私敏感：本插件暴露用户长期记忆与会话正文，authority 4（仅 sysop）门控所有
 // listener（读也拦），且服务端日志不落记忆/会话正文。这是原型 spike，正式版走 spec。
@@ -43,9 +44,17 @@ type ChatMsg = { time: number } & (
 
 declare module '@koishijs/console' {
   interface Events {
-    'llm-admin/search'(payload: { q: string }): AdminUser[]
+    'llm-admin/search'(payload: {
+      q: string
+      limit?: number
+      offset?: number
+    }): { total: number; users: AdminUser[] }
     'llm-admin/overview'(payload: { id: number }): UserOverview | null
-    'llm-admin/sessions'(payload: { id: number }): SessionRow[]
+    'llm-admin/sessions'(payload: {
+      id: number
+      limit?: number
+      offset?: number
+    }): { total: number; rows: SessionRow[] }
     'llm-admin/session'(payload: { conversationId: string }): ChatMsg[]
   }
 }
@@ -74,8 +83,7 @@ export function apply(ctx: Context) {
   // ---- 搜索：#id 精确 / platform:pid 子串 / 昵称子串 ----
   ctx.console.addListener(
     'llm-admin/search',
-    async ({ q }) => {
-      const query = (q ?? '').trim().toLowerCase()
+    async ({ q, limit = 50, offset = 0 }) => {
       // 候选池 = 有过会话的用户
       const sessions = await db.get(
         'openai_session',
@@ -84,21 +92,16 @@ export function apply(ctx: Context) {
       )
       const ids = [...new Set(sessions.map((s) => s.conversation_owner))]
       const { nameMap, acctMap } = await resolveIdentities(ids)
-      const all: AdminUser[] = ids.map((id) => ({
-        id,
-        name: nameMap.get(id) || '',
-        account: acctMap.get(id) || '',
-      }))
-      const matched = !query
-        ? all
-        : all.filter(
-            (u) =>
-              `#${u.id}` === query ||
-              String(u.id) === query ||
-              u.account.toLowerCase().includes(query) ||
-              u.name.toLowerCase().includes(query)
-          )
-      return matched.sort((a, b) => a.id - b.id).slice(0, 50)
+      const all: AdminUser[] = ids
+        .map((id) => ({
+          id,
+          name: nameMap.get(id) || '',
+          account: acctMap.get(id) || '',
+        }))
+        .filter((u) => matchUser(u, q))
+        .sort((a, b) => a.id - b.id)
+      const { total, page } = paginate(all, limit, offset)
+      return { total, users: page }
     },
     { authority: AUTH }
   )
@@ -128,7 +131,7 @@ export function apply(ctx: Context) {
   // ---- 会话列表：按最后活跃倒序 ----
   ctx.console.addListener(
     'llm-admin/sessions',
-    async ({ id }) => {
+    async ({ id, limit = 30, offset = 0 }) => {
       const rows = await db.get(
         'openai_session',
         { conversation_owner: id },
@@ -148,26 +151,36 @@ export function apply(ctx: Context) {
         { fields: ['openai_last_conversation_id'] }
       )
       const currentConv = (user[0] as any)?.openai_last_conversation_id ?? ''
-      // 每会话轮数（去重 turn_number）
-      const result: SessionRow[] = []
-      for (const s of rows) {
-        const chatRows = await db.get(
-          'openai_chat',
-          { conversation_id: s.conversation_id },
-          { fields: ['turn_number'] }
-        )
-        const turns = new Set(chatRows.map((c) => c.turn_number)).size
-        result.push({
-          conversationId: s.conversation_id,
-          title: s.user_first_msg || '(空)',
-          startedAt: s.started_at,
-          lastUsedAt: s.last_used_at,
-          isCurrent: s.conversation_id === currentConv,
-          isCompacted: !!s.prev_session_id,
-          turns,
-        })
+
+      const sorted = [...rows].sort((a, b) => b.last_used_at - a.last_used_at)
+      const { total, page } = paginate(sorted, limit, offset)
+
+      // 只对当前页 conversation_id 批量查一次轮数，避免 N+1
+      const convIds = page.map((s) => s.conversation_id)
+      const turnRows = convIds.length
+        ? await db.get(
+            'openai_chat',
+            { conversation_id: convIds },
+            { fields: ['conversation_id', 'turn_number'] }
+          )
+        : []
+      const turnSet = new Map<string, Set<number>>()
+      for (const t of turnRows) {
+        const set = turnSet.get(t.conversation_id) ?? new Set<number>()
+        set.add(t.turn_number)
+        turnSet.set(t.conversation_id, set)
       }
-      return result.sort((a, b) => b.lastUsedAt - a.lastUsedAt)
+
+      const out: SessionRow[] = page.map((s) => ({
+        conversationId: s.conversation_id,
+        title: s.user_first_msg || '(空)',
+        startedAt: s.started_at,
+        lastUsedAt: s.last_used_at,
+        isCurrent: s.conversation_id === currentConv,
+        isCompacted: !!s.prev_session_id,
+        turns: turnSet.get(s.conversation_id)?.size ?? 0,
+      }))
+      return { total, rows: out }
     },
     { authority: AUTH }
   )

--- a/plugins/llm-admin/index.ts
+++ b/plugins/llm-admin/index.ts
@@ -4,7 +4,11 @@ import { resolve } from 'node:path'
 
 import '@koishijs/console'
 
-import { type UserOverview, type UserUsageRow, aggregateUserOverview } from './aggregate-user'
+import {
+  type UserOverview,
+  type UserUsageRow,
+  aggregateUserOverview,
+} from './aggregate-user'
 import { matchUser, paginate } from './filters'
 import { checkMemoryWrite, utf8ByteLength } from './memory-edit'
 import { turnWindow } from './turns'
@@ -51,7 +55,7 @@ declare module '@koishijs/console' {
       limit?: number
       offset?: number
     }): { total: number; users: AdminUser[] }
-    'llm-admin/overview'(payload: { id: number }): UserOverview | null
+    'llm-admin/overview'(payload: { id: number }): UserOverview
     'llm-admin/sessions'(payload: {
       id: number
       limit?: number
@@ -148,8 +152,17 @@ export function apply(ctx: Context) {
         { fields: ['id'] }
       )
 
-      const identity = { id, name: nameMap.get(id) || '', account: acctMap.get(id) || '' }
-      return aggregateUserOverview(rows, sessionsOfUser.length, identity, Date.now())
+      const identity = {
+        id,
+        name: nameMap.get(id) || '',
+        account: acctMap.get(id) || '',
+      }
+      return aggregateUserOverview(
+        rows,
+        sessionsOfUser.length,
+        identity,
+        Date.now()
+      )
     },
     { authority: AUTH }
   )
@@ -388,11 +401,9 @@ export function apply(ctx: Context) {
       // activeChats 按 owner id 键；有在飞 chat 则把它写向新会话
       const active = ctx.llm.activeChats.get(id)
       if (active) active.conversationId = newId
-      ctx.logger('llm-admin').info(
-        '[rotate] user #%d rotated to fresh session %s',
-        id,
-        newId
-      )
+      ctx
+        .logger('llm-admin')
+        .info('[rotate] user #%d rotated to fresh session %s', id, newId)
       return { ok: true, conversationId: newId }
     },
     { authority: AUTH }

--- a/plugins/llm-admin/index.ts
+++ b/plugins/llm-admin/index.ts
@@ -6,6 +6,7 @@ import '@koishijs/console'
 
 import { type UserOverview, type UserUsageRow, aggregateUserOverview } from './aggregate-user'
 import { matchUser, paginate } from './filters'
+import { checkMemoryWrite, utf8ByteLength } from './memory-edit'
 import { turnWindow } from './turns'
 
 // ⚠ 隐私敏感：本插件暴露用户长期记忆与会话正文，authority 4（仅 sysop）门控所有
@@ -61,6 +62,21 @@ declare module '@koishijs/console' {
       limit?: number
       beforeTurn?: number | null
     }): { messages: ChatMsg[]; earliestTurn: number | null; hasMore: boolean }
+    // 隐私敏感：读也需 authority 4。content 绝不落服务端日志。
+    'llm-admin/memory-get'(payload: { id: number }): {
+      content: string
+      byteSize: number
+      updateCount: number
+      lastUpdated: number | null
+      platform: string | null
+      hardLimit: number
+    }
+    'llm-admin/memory-save'(payload: { id: number; content: string }): {
+      ok: boolean
+      byteSize: number
+      error?: string
+    }
+    'llm-admin/memory-clear'(payload: { id: number }): { ok: boolean }
   }
 }
 
@@ -266,6 +282,78 @@ export function apply(ctx: Context) {
         }
       })
       return { messages, earliestTurn: fromTurn, hasMore }
+    },
+    { authority: AUTH }
+  )
+
+  // ---- 长期记忆读/改/清（隐私敏感，仅 sysop；日志不落 content）----
+  // 记忆键：(platform, user_id)。前端只传 aid，故先按 user_id 查现有行拿 platform；
+  // 无现有行时从 binding 推断（onebot→qq 归一化）。
+  async function memoryRow(id: number) {
+    const rows = await db.get('openai_user_memory', { user_id: String(id) })
+    return rows[0] ?? null
+  }
+  async function memoryPlatform(id: number): Promise<string> {
+    const existing = await memoryRow(id)
+    if (existing?.platform) return existing.platform
+    const bindings = await db.get(
+      'binding',
+      { aid: id },
+      { fields: ['platform', 'bid'] }
+    )
+    const first = [...bindings].sort((x, y) => x.bid - y.bid)[0]
+    const p = first?.platform
+    return p === 'onebot' ? 'qq' : p || 'unknown'
+  }
+  // getMemoryHardLimit() 在 llm 插件里是 private，此处按同一策略自算
+  // （memory-fork.ts / index.tsx 均为 ceil(soft * 1.1)），避免上限漂移。
+  function memoryHardLimit(): number {
+    const soft = (ctx.llm as any).config?.memoryByteLimit ?? 3000
+    return Math.ceil(soft * 1.1)
+  }
+
+  ctx.console.addListener(
+    'llm-admin/memory-get',
+    async ({ id }) => {
+      const row = await memoryRow(id)
+      return {
+        content: row?.content ?? '',
+        byteSize: row?.byte_size ?? 0,
+        updateCount: row?.update_count ?? 0,
+        lastUpdated: row?.last_updated_at ?? null,
+        platform: row?.platform ?? null,
+        hardLimit: memoryHardLimit(),
+      }
+    },
+    { authority: AUTH }
+  )
+
+  ctx.console.addListener(
+    'llm-admin/memory-save',
+    async ({ id, content }) => {
+      const check = checkMemoryWrite(content, memoryHardLimit())
+      if (!check.ok) return check
+      const existing = await memoryRow(id)
+      const platform = existing?.platform ?? (await memoryPlatform(id))
+      // 保留 fork 节流元数据，避免打乱后台记忆调度
+      await ctx.llm.memory.set(
+        platform,
+        String(id),
+        content,
+        existing?.message_count_at_update ?? 0,
+        existing?.last_forked_conversation_id ?? ''
+      )
+      return { ok: true, byteSize: utf8ByteLength(content) }
+    },
+    { authority: AUTH }
+  )
+
+  ctx.console.addListener(
+    'llm-admin/memory-clear',
+    async ({ id }) => {
+      const platform = await memoryPlatform(id)
+      const ok = await ctx.llm.memory.delete(platform, String(id))
+      return { ok }
     },
     { authority: AUTH }
   )

--- a/plugins/llm-admin/memory-edit.ts
+++ b/plugins/llm-admin/memory-edit.ts
@@ -1,0 +1,17 @@
+export function utf8ByteLength(s: string): number {
+  return new TextEncoder().encode(s).length
+}
+
+export function checkMemoryWrite(
+  content: string,
+  hardLimit: number
+): { ok: boolean; byteSize: number; error?: string } {
+  const byteSize = utf8ByteLength(content)
+  if (byteSize > hardLimit)
+    return {
+      ok: false,
+      byteSize,
+      error: `记忆超出字节上限（${byteSize} > ${hardLimit}）`,
+    }
+  return { ok: true, byteSize }
+}

--- a/plugins/llm-admin/package.json
+++ b/plugins/llm-admin/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "koishi-plugin-llm-admin",
+  "version": "0.0.0",
+  "private": true,
+  "description": "LLM per-user admin console for SILI (memory / session management)",
+  "main": "index.ts",
+  "peerDependencies": {
+    "koishi": "^4.18.0"
+  }
+}

--- a/plugins/llm-admin/turns.ts
+++ b/plugins/llm-admin/turns.ts
@@ -1,0 +1,13 @@
+// turnNumbers 已升序去重。返回本批要包含的最小 turn（fromTurn，含）与是否还有更早。
+export function turnWindow(
+  turnNumbers: number[],
+  limit: number,
+  beforeTurn: number | null
+): { fromTurn: number | null; hasMore: boolean } {
+  if (!turnNumbers.length) return { fromTurn: null, hasMore: false }
+  const eligible =
+    beforeTurn == null ? turnNumbers : turnNumbers.filter((t) => t < beforeTurn)
+  if (!eligible.length) return { fromTurn: null, hasMore: false }
+  const startIdx = Math.max(0, eligible.length - limit)
+  return { fromTurn: eligible[startIdx], hasMore: startIdx > 0 }
+}

--- a/plugins/llm-dashboard/client/index.js
+++ b/plugins/llm-dashboard/client/index.js
@@ -1,5 +1,6 @@
 import { defineComponent, h, onMounted, ref, resolveComponent, watch } from '../vue.js'
-import { send, store } from '../client.js'
+import { useRouter } from '../vue-router.js'
+import { icons, send, store } from '../client.js'
 
 const RANGES = [
   { value: 7, label: '7 天' },
@@ -62,13 +63,21 @@ function overviewCards(o) {
   )
 }
 
-function rankRows(items, maxKey, rows) {
+function rankRows(items, maxKey, rows, onRowClick) {
   const max = Math.max(1, ...items.map((it) => it[maxKey]))
   return items.map((it) =>
-    h('div', { class: 'ld-rank-row', key: it.model ?? it.id }, [
-      h('div', { class: 'ld-rank-bar', style: `width:${(it[maxKey] / max) * 100}%` }),
-      h('div', { class: 'ld-rank-content' }, rows(it)),
-    ])
+    h(
+      'div',
+      {
+        class: ['ld-rank-row', onRowClick ? 'ld-rank-clickable' : ''],
+        key: it.model ?? it.id,
+        ...(onRowClick ? { onClick: () => onRowClick(it) } : {}),
+      },
+      [
+        h('div', { class: 'ld-rank-bar', style: `width:${(it[maxKey] / max) * 100}%` }),
+        h('div', { class: 'ld-rank-content' }, rows(it)),
+      ]
+    )
   )
 }
 
@@ -99,30 +108,39 @@ function modelPanel(models) {
   )
 }
 
-function userPanel(users) {
+function userPanel(users, onUserClick) {
   const KCard = resolveComponent('k-card')
   return h(
     KCard,
     { class: 'ld-panel' },
     {
       default: () => [
-        h('div', { class: 'ld-panel-title' }, 'TOP 用户'),
+        h(
+          'div',
+          { class: 'ld-panel-title' },
+          onUserClick ? 'TOP 用户 · 点击进入管理' : 'TOP 用户'
+        ),
         users.length
           ? h(
               'div',
               { class: 'ld-ranks' },
-              rankRows(users, 'totalTokens', (u) => [
-                h('span', { class: 'ld-rank-name' }, [
-                  u.name ? h('span', { class: 'ld-user-nick' }, u.name) : null,
-                  u.account ? h('span', { class: 'ld-user-acct' }, u.account) : null,
-                  h('span', { class: 'ld-user-uid' }, `(#${u.id})`),
-                ]),
-                h(
-                  'span',
-                  { class: 'ld-rank-metric' },
-                  `${fmtShort(u.totalTokens)} tok (入 ${fmtShort(u.promptTokens)} / 出 ${fmtShort(u.completionTokens)}) · ${fmt(u.conversations)} 会话`
-                ),
-              ])
+              rankRows(
+                users,
+                'totalTokens',
+                (u) => [
+                  h('span', { class: 'ld-rank-name' }, [
+                    u.name ? h('span', { class: 'ld-user-nick' }, u.name) : null,
+                    u.account ? h('span', { class: 'ld-user-acct' }, u.account) : null,
+                    h('span', { class: 'ld-user-uid' }, `(#${u.id})`),
+                  ]),
+                  h(
+                    'span',
+                    { class: 'ld-rank-metric' },
+                    `${fmtShort(u.totalTokens)} tok (入 ${fmtShort(u.promptTokens)} / 出 ${fmtShort(u.completionTokens)}) · ${fmt(u.conversations)} 会话`
+                  ),
+                ],
+                onUserClick
+              )
             )
           : h('p', { class: 'ld-empty' }, '（无数据）'),
       ],
@@ -202,6 +220,12 @@ const Dashboard = defineComponent({
       load()
     }
 
+    // 点 TOP 用户 → 跳到用户管理台并定位该用户（仅 sysop，见下方 authority 门）
+    const router = useRouter()
+    function openAdminUser(u) {
+      router.push({ path: '/llm-admin', query: { user: u.id } })
+    }
+
     onMounted(() => {
       if (store.user) load()
       else {
@@ -221,6 +245,8 @@ const Dashboard = defineComponent({
       const KLayout = resolveComponent('k-layout')
       const KCard = resolveComponent('k-card')
       const s = stats.value
+      // 管理台是 authority 4 仅 sysop；低权限用户不给可点入口，避免点了跳去被拦
+      const canAdmin = (store.user?.authority ?? 0) >= 4
 
       const toolbar = h('div', { class: 'ld-toolbar' }, [
         h(
@@ -244,7 +270,10 @@ const Dashboard = defineComponent({
           : h('div', { class: 'ld-grid' }, [
               overviewCards(s.overview),
               trendPanel(s.trend),
-              h('div', { class: 'ld-panels' }, [modelPanel(s.models), userPanel(s.users)]),
+              h('div', { class: 'ld-panels' }, [
+                modelPanel(s.models),
+                userPanel(s.users, canAdmin ? openAdminUser : null),
+              ]),
             ])
 
       return h(KLayout, null, { default: () => h('div', { class: 'ld-root' }, [toolbar, content]) })
@@ -253,11 +282,21 @@ const Dashboard = defineComponent({
 })
 
 export default (ctx) => {
+  // 侧栏图标：柱状图（用量），与用户管理台的人形图标区分
+  icons.register('llm-usage', {
+    render: () =>
+      h('svg', { viewBox: '0 0 24 24', fill: 'currentColor', xmlns: 'http://www.w3.org/2000/svg' }, [
+        h('rect', { x: 3, y: 12, width: 4, height: 8, rx: 1 }),
+        h('rect', { x: 10, y: 7, width: 4, height: 13, rx: 1 }),
+        h('rect', { x: 17, y: 3, width: 4, height: 17, rx: 1 }),
+      ]),
+  })
   ctx.page({
     path: '/llm-dashboard',
     name: 'LLM 用量',
     authority: 3,
     order: 100,
+    icon: 'llm-usage',
     component: Dashboard,
   })
 }

--- a/plugins/llm-dashboard/client/style.css
+++ b/plugins/llm-dashboard/client/style.css
@@ -30,6 +30,8 @@
 @media (max-width: 900px) { .ld-panels { grid-template-columns: 1fr; } }
 .ld-ranks { display: flex; flex-direction: column; gap: 0.3rem; }
 .ld-rank-row { position: relative; padding: 0.4rem 0.6rem; border-radius: 4px; overflow: hidden; }
+.ld-rank-clickable { cursor: pointer; transition: background 0.12s; }
+.ld-rank-clickable:hover { background: var(--k-hover-bg, rgba(128, 128, 128, 0.1)); }
 .ld-rank-bar {
   position: absolute; inset: 0 auto 0 0; background: var(--k-color-primary, #6a5acd);
   opacity: 0.14; border-radius: 4px;

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,7 @@ import * as PluginDialogueContext from 'koishi-plugin-dialogue-context'
 import * as PluginDialogueFlow from 'koishi-plugin-dialogue-flow'
 import * as PluginDialogueRateLimit from 'koishi-plugin-dialogue-rate-limit'
 import * as PluginImageSearch from 'koishi-plugin-image-search'
+import * as PluginLlmAdmin from 'koishi-plugin-llm-admin'
 import * as PluginLlmDashboard from 'koishi-plugin-llm-dashboard'
 import * as PluginManosabaMemes from 'koishi-plugin-manosaba-memes'
 import * as PluginNovelAi from 'koishi-plugin-novelai'
@@ -310,6 +311,7 @@ app.plugin(function PluginCollectionConsole(ctx) {
   ctx.plugin(PluginStatus)
   ctx.plugin(PluginSandbox)
   ctx.plugin(PluginLlmDashboard)
+  ctx.plugin(PluginLlmAdmin)
 })
 
 // 第三方


### PR DESCRIPTION
## LLM 按用户管理控制台

给 SILI 的 LLM 插件新增一个 **koishi console 页面**（`plugins/llm-admin/`，独立 workspace 包 `koishi-plugin-llm-admin`），供 sysop 按用户搜索 → 查看用量总览与会话历史（聊天软件式回放）→ 管理长期记忆、强制轮转 session。

### 功能

- **搜索**：`#id` 精确 / `platform:pid` 与昵称子串，limit/offset 分页。
- **用量总览**：token in/out/cached 拆分、近 30 天趋势、模型分布、会话数、活跃区间。
- **会话回放**：聊天软件式，默认最近 20 轮、向上无限滚动（IntersectionObserver）加载更早；思维链 / 工具调用 / 工具结果 / 原始 envelope 默认折叠；每条 agent 消息展示 token 消耗（↑输入 ↓输出 ⚡缓存）。
- **长期记忆编辑**：读 / 改 / 清（二次确认），UTF-8 字节计数对上限；`platform==='unknown'` 拒绝孤儿写入。
- **强制轮转**：纯新开会话（不压缩、不带 prev_session_id），二次确认。
- **入口**：仪表盘 TOP 用户可点跳转（仅 sysop）+ 本页搜索；两页独立侧栏图标。

### 权限与隐私

- **authority 4（仅 sysop）** 门控页面 + 全部 8 个 listener（读也拦）。
- 服务端日志不落记忆 / 会话正文，只记 id / 计数。
- 破坏性写操作 UI 二次确认；回放默认只拉最近 N 轮。

### 质量

- 纯函数（聚合 / 过滤分页 / turn 窗口 / 记忆字节检查）单测覆盖；全仓 778 tests 绿。
- 走 spec → plan → subagent-driven 逐任务实现 + 逐任务评审 + 全分支 final review；读侧与导航在浏览器实测通过。
- sessions 列表修掉 N+1（按当前页批量查一次轮数）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

引入每用户的 LLM 管理控制台，提供安全的记忆和会话管理，并与现有的使用量仪表盘集成。

New Features:
- 添加新的 authority-4 koishi 控制台页面 `/llm-admin`，用于每个用户的 LLM 管理，包括搜索、使用概览、会话列表以及聊天式会话回放。
- 为每个用户提供前端长期记忆编辑器，支持查看、编辑、按字节大小对限制进行校验，并在确认后清空记忆。
- 添加强制会话轮换操作，可为用户创建一个不经压缩的新 LLM 会话，并在后端及控制台 UI 中打通该功能。
- 为 LLM 使用量仪表盘和新的用户管理控制台分别注册不同的侧边栏图标，以区分各自的导航入口。

Bug Fixes:
- 通过按页面批量查询轮次计数，消除会话列表中的 N+1 查询模式。

Enhancements:
- 将用户使用量聚合逻辑抽取为可复用的纯函数，并为令牌计算、模型排名和趋势生成添加单元测试。
- 为用户搜索和会话 API 添加可复用的过滤与分页助手，支持带总数的 limit/offset 分页。
- 为会话回放实现基于轮次窗口的分页，以支持通过无限滚动增量加载更早的轮次。
- 在新的管理端点中强制严格的权限控制，并避免记录记忆或会话内容，以保护用户隐私。

Build:
- 添加新的 `koishi-plugin-llm-admin` workspace 包及锁文件条目，以将管理控制台集成进项目。

Documentation:
- 添加针对每用户 LLM 管理控制台的设计与实现方案文档，涵盖架构、权限、数据模型和用户体验（UX）。

Tests:
- 在 llm-admin 模块中加入 vitest 测试套件，用于使用量聚合、用户过滤与分页、轮次窗口计算以及记忆字节上限校验。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a per-user LLM admin console with secure memory and session management, and integrate it with the existing usage dashboard.

New Features:
- Add a new authority-4 koishi console page `/llm-admin` for per-user LLM administration, including search, usage overview, session list, and chat-style session replay.
- Provide a front-end long-term memory editor for each user, supporting viewing, editing, byte-size validation against limits, and clearing memory with confirmation.
- Add a force session rotation action that creates a fresh LLM session for a user without compaction, wired into both backend and console UI.
- Register distinct sidebar icons for the LLM usage dashboard and the new user admin console to differentiate their navigation entries.

Bug Fixes:
- Eliminate an N+1 query pattern in the sessions listing by batching turn count lookups per page.

Enhancements:
- Extract user usage aggregation logic into a reusable pure function with unit tests for token math, model ranking, and trend generation.
- Add reusable filtering and pagination helpers for user search and sessions APIs, enabling limit/offset pagination with total counts.
- Implement turn-window based pagination for session replay to support incremental loading of older turns via infinite scroll.
- Enforce strict authority gating and avoid logging memory or session contents in the new admin endpoints to protect user privacy.

Build:
- Add the new `koishi-plugin-llm-admin` workspace package and lockfile entries for integrating the admin console into the project.

Documentation:
- Add design and implementation plan documents for the LLM per-user admin console, covering architecture, permissions, data model, and UX.

Tests:
- Introduce vitest suites for usage aggregation, user filters and pagination, turn window computation, and memory byte-limit validation in the llm-admin module.

</details>