### PR TITLE
fix(llm-admin): 窄屏响应式布局 + 消息预览模型名

### DIFF
--- a/plugins/llm-admin/client/index.js
+++ b/plugins/llm-admin/client/index.js
@@ -281,13 +281,16 @@ function renderMsg(m) {
   if (m.role === 'assistant' && m.toolCalls)
     kids.push(fold('la-tool', `🔧 调用 ${toolNames(m.toolCalls)}`, prettyJson(m.toolCalls)))
   const label = m.role === 'user' ? '用户' : m.role === 'assistant' ? 'SILI' : m.role
+  const roleKids = [h('span', { class: 'la-msg-name' }, label)]
+  if (m.role === 'assistant' && m.model)
+    roleKids.push(h('span', { class: 'la-msg-model' }, m.model))
   const meta = [h('span', { class: 'la-msg-time' }, when(m.time))]
   if (m.role === 'assistant') {
     const t = msgTokens(m.usage)
     if (t) meta.push(t)
   }
   return h('div', { class: `la-msg la-msg-${m.role}` }, [
-    h('div', { class: 'la-msg-role' }, label),
+    h('div', { class: 'la-msg-role' }, roleKids),
     h('div', { class: 'la-bubble' }, kids),
     h('div', { class: 'la-msg-meta' }, meta),
   ])

--- a/plugins/llm-admin/client/index.js
+++ b/plugins/llm-admin/client/index.js
@@ -385,6 +385,18 @@ const Admin = defineComponent({
     }
     const goSearch = () => router.push({ path: '/llm-admin', query: {} })
 
+    // 窄屏「导航栈」：会话列表打底，详情从右滑入覆盖。宽屏是并排 split view，此状态被忽略。
+    // 聊天层走 ?session 路由；总览层因宽屏常驻右栏、窄屏才需显式打开，用本地 overviewOpen。
+    const overviewOpen = ref(false)
+    const onHeadClick = () => {
+      if (cid()) backToOverview()
+      else overviewOpen.value = true
+    }
+    const closePane = () => {
+      if (cid()) backToOverview()
+      else overviewOpen.value = false
+    }
+
     let loadedUser = null
     let loadedConv = null
     async function loadUser(id) {
@@ -523,6 +535,7 @@ const Admin = defineComponent({
       () => [ready.value, route.query.user, route.query.session],
       () => {
         if (!ready.value) return
+        overviewOpen.value = false // 任何路由变化都收起窄屏总览覆盖层
         const u = uid()
         const c = cid()
         if (u == null) {
@@ -612,9 +625,9 @@ const Admin = defineComponent({
         h(
           'div',
           {
-            class: ['la-user-head', inSession ? 'clickable' : ''],
-            title: inSession ? '点此返回用户总览' : '',
-            onClick: backToOverview,
+            class: ['la-user-head', inSession ? 'clickable' : 'la-head-tap'],
+            title: inSession ? '点此返回用户总览' : '点此查看用户总览',
+            onClick: onHeadClick,
           },
           [
             h('div', { class: 'la-user-head-top' }, [
@@ -673,15 +686,26 @@ const Admin = defineComponent({
               : [h('p', { class: 'la-dim' }, '（无会话）')]
         ),
       ])
-      const right = h('div', { class: 'la-right', ref: chatEl }, [
-        err.value ? h('div', { class: 'la-err' }, err.value) : null,
-        inSession
-          ? chatView(msgs.value, sentinelEl, loadingMoreMsgs.value)
-          : o
-            ? overviewView(o)
-            : h('div', { class: 'la-dim' }, '加载中…'),
+      const paneOpen = inSession || overviewOpen.value
+      const paneTitle = inSession
+        ? sessions.value?.find((s) => s.conversationId === cid())?.title || '会话回放'
+        : '用户总览'
+      const pane = h('div', { class: ['la-detail-pane', paneOpen ? 'la-pane-open' : ''] }, [
+        // 窄屏导航栏（宽屏 CSS 隐藏）：返回 + 标题
+        h('div', { class: 'la-pane-bar' }, [
+          h('button', { class: 'la-pane-back', onClick: closePane }, '← 返回'),
+          h('div', { class: 'la-pane-title' }, paneTitle),
+        ]),
+        h('div', { class: 'la-right', ref: chatEl }, [
+          err.value ? h('div', { class: 'la-err' }, err.value) : null,
+          inSession
+            ? chatView(msgs.value, sentinelEl, loadingMoreMsgs.value)
+            : o
+              ? overviewView(o)
+              : h('div', { class: 'la-dim' }, '加载中…'),
+        ]),
       ])
-      return h('div', { class: 'la-detail' }, [left, right])
+      return h('div', { class: 'la-detail' }, [left, pane])
     }
 
     return () => {

--- a/plugins/llm-admin/client/style.css
+++ b/plugins/llm-admin/client/style.css
@@ -33,11 +33,14 @@
 .la-uid { color: var(--k-text-light, #999); font-size: 0.85em; }
 
 /* ---------- 详情：master-detail ---------- */
-.la-detail { flex: 1; min-height: 0; display: grid; grid-template-columns: 320px 1fr; }
+.la-detail { flex: 1; min-height: 0; position: relative; display: grid; grid-template-columns: 320px 1fr; }
 .la-left {
   min-height: 0; display: flex; flex-direction: column;
   border-right: 1px solid var(--k-color-border, #eee);
 }
+/* 详情栏外壳：宽屏是右侧 split view 面板；窄屏变从右滑入的导航层（见文末媒体查询） */
+.la-detail-pane { min-height: 0; display: flex; flex-direction: column; }
+.la-pane-bar { display: none; } /* 宽屏无导航栏 */
 .la-user-head {
   padding: 1rem; border-bottom: 1px solid var(--k-color-border, #eee);
   position: sticky; top: 0; background: var(--k-page-bg, var(--k-card-bg, #fff)); z-index: 1;
@@ -87,7 +90,7 @@
 }
 .la-badge-cur { background: var(--k-color-primary, #6a5acd); color: #fff; }
 
-.la-right { min-height: 0; overflow-y: auto; padding: 1.2rem; display: flex; flex-direction: column; }
+.la-right { flex: 1; min-height: 0; overflow-y: auto; padding: 1.2rem; display: flex; flex-direction: column; }
 
 /* ---------- 总览 ---------- */
 .la-overview { display: flex; flex-direction: column; gap: 1rem; }
@@ -162,3 +165,48 @@
   border: 1px solid var(--k-color-danger, #e0533d);
 }
 .la-mem-msg { font-size: 0.8rem; color: var(--k-text-light, #999); }
+
+/* ---------- 窄屏：iOS split view 折叠成导航栈 ---------- */
+/* 宽屏 = 会话列表 + 详情并排；窄屏 = 会话列表打底，详情层从右滑入覆盖，顶部返回栏 */
+@media (max-width: 720px) {
+  /* 列表铺满；详情层 absolute 覆盖其上。overflow:hidden 裁掉滑出屏幕的详情层，
+     否则 translateX(100%) 会撑出横向滚动、把头部按钮挤出视口 */
+  .la-detail { grid-template-columns: 1fr; overflow: hidden; }
+  .la-left { border-right: none; }
+
+  /* 会话列表顶部的用户区可点 → 打开总览层 */
+  .la-user-head.la-head-tap { cursor: pointer; }
+  .la-user-head.la-head-tap::after {
+    content: '›'; position: absolute; right: 0.9rem; top: 50%; transform: translateY(-50%);
+    color: var(--k-color-primary, #6a5acd); font-size: 1.2rem; line-height: 1;
+  }
+  .la-user-head { position: relative; }
+
+  /* 详情层：从右滑入的覆盖层 */
+  .la-detail-pane {
+    position: absolute; inset: 0; z-index: 20;
+    background: var(--k-page-bg, var(--k-card-bg, #fff));
+    transform: translateX(100%);
+    transition: transform 0.22s ease;
+    box-shadow: -8px 0 24px rgba(0, 0, 0, 0.12);
+  }
+  .la-detail-pane.la-pane-open { transform: translateX(0); }
+
+  /* 顶部导航栏：返回 + 标题 */
+  .la-pane-bar {
+    display: flex; align-items: center; gap: 0.6rem; flex: none;
+    padding: 0.6rem 0.9rem; border-bottom: 1px solid var(--k-color-border, #eee);
+    background: var(--k-page-bg, var(--k-card-bg, #fff));
+  }
+  .la-pane-back {
+    background: none; border: none; cursor: pointer; padding: 0.2rem 0;
+    color: var(--k-color-primary, #6a5acd); font-size: 0.9rem; white-space: nowrap;
+  }
+  .la-pane-title {
+    font-weight: 600; font-size: 0.9rem;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+
+  .la-right { padding: 1rem; }
+  .la-cards { grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); } /* 卡片更紧凑 */
+}

--- a/plugins/llm-admin/client/style.css
+++ b/plugins/llm-admin/client/style.css
@@ -119,7 +119,14 @@
 .la-chat-empty { padding: 2rem; text-align: center; }
 .la-chat-more { text-align: center; font-size: 0.78rem; padding: 0.3rem 0; }
 .la-msg { display: flex; flex-direction: column; gap: 0.2rem; }
-.la-msg-role { font-size: 0.72rem; color: var(--k-text-light, #999); }
+.la-msg-role {
+  display: flex; align-items: center; gap: 0.4rem;
+  font-size: 0.72rem; color: var(--k-text-light, #999);
+}
+.la-msg-model {
+  font-size: 0.68rem; color: var(--k-color-primary, #6a5acd);
+  font-variant-numeric: tabular-nums;
+}
 .la-msg-meta { display: flex; gap: 0.5rem; align-items: baseline; margin-top: 0.15rem; flex-wrap: wrap; }
 .la-msg-time { font-size: 0.68rem; color: var(--k-text-light, #999); }
 .la-msg-tokens {

--- a/plugins/llm-admin/index.ts
+++ b/plugins/llm-admin/index.ts
@@ -46,6 +46,7 @@ type ChatMsg = { time: number } & (
       reasoning?: string
       toolCalls?: string
       usage?: Usage | null // 该次 agent 调用的 token 消耗，供逐条展示
+      model?: string // 该次 agent 调用所用模型，供逐条展示
     }
   | { role: 'tool'; toolName?: string; content: string }
 )
@@ -259,6 +260,7 @@ export function apply(ctx: Context) {
             'tool_name',
             'time',
             'usage',
+            'model',
           ],
           sort: { turn_number: 'asc', intra_turn_seq: 'asc', id: 'asc' },
         } as any
@@ -270,6 +272,7 @@ export function apply(ctx: Context) {
         tool_name: string
         time: number
         usage: Usage | null
+        model: string
       }>
 
       // user 行存的是包装 envelope，抽取 <user_message> 内层供展示
@@ -302,6 +305,7 @@ export function apply(ctx: Context) {
           reasoning: r.reasoning_content || undefined,
           toolCalls: r.tool_calls || undefined,
           usage: r.usage ?? null,
+          model: r.model || undefined,
         }
       })
       return { messages, earliestTurn: fromTurn, hasMore }


### PR DESCRIPTION
LLM 用户管理控制台两处 UI 优化。

## 窄屏响应式（`9c727e3`）
屏幕 ≤720px 时，宽屏的 split view 收缩为 iOS 式导航栈：
- 会话列表作为基础层
- 点击用户头部 → 滑出「用户总览」drawer
- 点击某会话 → 滑出「会话回放」drawer（含固定顶部导航条：返回 + 标题）
- 宽屏/桌面 split view 保持不变

## 消息预览模型名（`e20f562`）
每条 agent 消息透传 `model` 字段，在「SILI」名字后以纯文本展示当次调用所用模型，回放时逐轮模型切换一目了然。

## 验证
- 全仓 778 tests 绿
- 浏览器实测：窄屏 drawer 交互 + 宽屏回归 + 模型名逐条展示（deepseek-v4-pro / gemini-3.5-flash）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

提升在窄屏设备上的 llm-admin 控制台响应式体验，并在聊天回放中展示每条消息所使用的模型信息。

新功能：
- 在聊天预览和回放中，在代理标签旁显示每条助手消息所使用的底层模型名称。

改进：
- 为 ≤720px 屏幕添加可折叠的导航栈界面，将分屏视图改为带有概览与会话回放标题栏的覆盖式抽屉布局。
- 优化消息头部布局和卡片网格间距，使其更适配小屏幕。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve llm-admin console responsiveness on narrow screens and surface per-message model information in chat replay.

New Features:
- Display the underlying model name for each assistant message alongside the agent label in chat previews and replays.

Enhancements:
- Add a collapsible navigation stack UI for ≤720px screens, turning the split view into overlay drawers with a header bar for overview and session playback.
- Refine message header layout and card grid spacing to better fit small screens.

</details>